### PR TITLE
feat(fastlane): add personal timeline for quick thought captures

### DIFF
--- a/.cursor/rules/add-donepudi-me-fastlane-entry.mdc
+++ b/.cursor/rules/add-donepudi-me-fastlane-entry.mdc
@@ -1,0 +1,200 @@
+---
+description: Action rule to quickly capture thoughts and moments to the Fastlane personal timeline
+globs: []
+alwaysApply: false
+---
+
+# Rule: Add Fastlane Entry
+
+**Purpose**: Quickly capture thoughts, observations, and moments to the Fastlane personal timeline with minimal friction.
+
+**Type**: Action rule
+
+**When to use**: User says "fastlane:", "add to fastlane", "fastlane entry", or provides content they want to add to their timeline.
+
+---
+
+## Philosophy
+
+Fastlane is for capturing life's moments without the overhead of polished blog posts. Speed matters. Authenticity matters. Don't over-structure or over-polish - preserve the raw voice.
+
+---
+
+## Inputs User Will Provide
+
+The user will provide one or more of:
+
+1. **Title**: Explicitly stated or extractable from content
+2. **Content**: Raw thoughts, observations, or reflections
+3. **Tags**: Optionally mentioned or inferable from context
+
+**Examples of triggers:**
+- "fastlane: Just realized that consistency beats intensity"
+- "add to fastlane - thoughts on building in public"
+- "fastlane entry about today's breakthrough"
+
+---
+
+## What You Must Do
+
+### 1. Extract or Generate Title
+
+If title is explicit, use it. Otherwise, extract from the first sentence or generate a concise title that captures the essence.
+
+**Good titles:**
+- Short, punchy (under 10 words)
+- Captures the core thought
+- Doesn't need to be clever or catchy
+
+### 2. Get Today's Date
+
+Use the current date in `YYYY-MM-DD` format.
+
+### 3. Generate Slug
+
+Create URL-friendly slug from title:
+- Convert to lowercase
+- Replace spaces with hyphens
+- Remove special characters except hyphens
+- Keep it concise
+
+**Example:** "Why I Read at 5 AM" → `why-i-read-at-5-am`
+
+### 4. Suggest Tags (Optional)
+
+If the content naturally fits certain themes, suggest 1-3 tags:
+
+| Theme | Suggested Tags |
+|-------|---------------|
+| Personal growth | `reflection`, `personal`, `growth` |
+| Planton/work | `planton`, `startup`, `work` |
+| Productivity | `productivity`, `discipline`, `habits` |
+| Reading/learning | `reading`, `learning`, `books` |
+| Technical | `engineering`, `code`, `infrastructure` |
+| Life observations | `life`, `observation`, `wisdom` |
+
+Tags are optional - don't force them if the content doesn't fit neatly.
+
+### 5. Create the File
+
+**Location:** `donepudi.me/public/fastlane/YYYY-MM-DD-slug.md`
+
+**Structure:**
+```yaml
+---
+title: "The Title Here"
+date: "YYYY-MM-DD"
+tags: ["tag1", "tag2"]  # Optional, omit if none
+---
+
+Content here...
+
+Preserve the user's voice exactly. Don't restructure, don't add headings unless the content naturally needs them.
+```
+
+### 6. Preserve Authentic Voice
+
+**DO:**
+- Keep the original phrasing
+- Preserve paragraph breaks
+- Fix obvious typos only
+- Add markdown links for URLs if present
+
+**DON'T:**
+- Restructure the content
+- Add headers where there were none
+- Change the tone or voice
+- Add commentary or conclusions
+- Over-polish casual thoughts
+
+---
+
+## File Naming Convention
+
+`YYYY-MM-DD-slug.md`
+
+**Examples:**
+- `2026-01-21-why-consistency-beats-intensity.md`
+- `2026-01-21-building-in-public.md`
+- `2026-01-21-5am-reading-habit.md`
+
+---
+
+## Frontmatter Schema
+
+```yaml
+---
+title: "Required - the entry title"
+date: "YYYY-MM-DD"
+tags: ["optional", "array", "of", "tags"]
+---
+```
+
+**Required fields:**
+- `title` - Entry title
+- `date` - Publication date
+
+**Optional fields:**
+- `tags` - Array of lowercase tags
+
+**NOT needed (unlike blog):**
+- `excerpt` - Auto-generated from content
+- `featured_image` - Not used in Fastlane
+- `author` - Always Swarup
+
+---
+
+## Example Workflow
+
+**User says:**
+> fastlane: Just had a realization while reading The Millionaire Fastlane again. Life really is single-threaded. Every day you wake up, you're on the same lane as yesterday. No branching, no parallel paths. The only variable is your speed and direction. That's why I named this feature Fastlane.
+
+**You create:** `donepudi.me/public/fastlane/2026-01-21-life-is-single-threaded.md`
+
+```yaml
+---
+title: "Life is Single-Threaded"
+date: "2026-01-21"
+tags: ["reflection", "reading"]
+---
+
+Just had a realization while reading The Millionaire Fastlane again. Life really is single-threaded. Every day you wake up, you're on the same lane as yesterday. No branching, no parallel paths. The only variable is your speed and direction.
+
+That's why I named this feature Fastlane.
+```
+
+---
+
+## Quick Reference
+
+| Field | Required | Format |
+|-------|----------|--------|
+| File location | - | `public/fastlane/YYYY-MM-DD-slug.md` |
+| title | Yes | String in quotes |
+| date | Yes | YYYY-MM-DD |
+| tags | No | Array of lowercase strings |
+
+---
+
+## Quality Checklist
+
+Before completing:
+
+- [ ] File named correctly: `YYYY-MM-DD-slug.md`
+- [ ] Frontmatter is valid YAML
+- [ ] Date matches today (unless user specified otherwise)
+- [ ] Title is concise and captures the essence
+- [ ] Content preserves user's authentic voice
+- [ ] Tags are relevant (or omitted if none fit)
+- [ ] No over-structuring or over-polishing
+
+---
+
+## Notes
+
+- **Location:** `donepudi.me/public/fastlane/`
+- **Access:** `/fastlane` (no navigation link - discovered only by URL)
+- **Purpose:** Quick captures, not polished posts
+- **Speed:** This should take seconds, not minutes
+
+**Remember:** The goal is minimal friction. Get the thought captured quickly and authentically. Polish is for blog posts.

--- a/_changelog/2025-11-26-070027-add-date-prefixes-to-blog-posts-and-images.md
+++ b/_changelog/2025-11-26-070027-add-date-prefixes-to-blog-posts-and-images.md
@@ -175,13 +175,13 @@ Used shell `mv` commands to rename files in batch operations:
 
 ```bash
 # Blog posts
-cd /Users/swarup/scm/github.com/swarupdonepudi/donepudi.me/public/blog
+cd ~/scm/github.com/swarupdonepudi/donepudi.me/public/blog
 mv 37-signals-in-datacenter.md 2025-03-18-37-signals-in-datacenter.md
 mv planton-will-become-the-next-postman.md 2025-11-25-planton-will-become-the-next-postman.md
 # ... (15 more files)
 
 # Images
-cd /Users/swarup/scm/github.com/swarupdonepudi/donepudi.me/public/blog/images
+cd ~/scm/github.com/swarupdonepudi/donepudi.me/public/blog/images
 mv planton-will-become-the-next-postman.cover.png 2025-11-25-planton-will-become-the-next-postman.cover.png
 mv planton-will-become-the-next-postman-logos.png 2025-11-25-planton-will-become-the-next-postman-logos.png
 # ... (30 more files)

--- a/_changelog/2026-01-21-085038-bootstrap-courses-section-with-teaching-components.md
+++ b/_changelog/2026-01-21-085038-bootstrap-courses-section-with-teaching-components.md
@@ -1,0 +1,541 @@
+# Bootstrap Courses Section with Teaching Components
+
+**Date**: January 21, 2026
+**Type**: Feature
+**Areas**: Content, UI Components, Navigation, Design System
+
+## Summary
+
+Built a complete courses section for donepudi.me with specialized teaching components, course/lesson management infrastructure, and starter content for "Practical Unix" and "Terraform Fundamentals" courses. The system supports interactive learning with terminal demonstrations, callouts, command explanations, and progress tracking. The courses section is fully functional but temporarily removed from navigation while content is being developed.
+
+## Motivation / Background
+
+The portfolio site had Blog for written content and Talks for presentations, but lacked a structured way to teach technical skills through hands-on courses. Creating courses allows sharing knowledge in a more structured, progressive format with interactive elements that books and blog posts can't provide.
+
+### Goals
+- Create reusable teaching components suitable for technical education
+- Build a flexible course/lesson system that scales
+- Provide rich interactive elements (terminal blocks, callouts, command breakdowns)
+- Start with two practical courses: Unix fundamentals and Terraform
+- Maintain consistency with existing Blog/Talks patterns
+
+## What Changed
+
+Added a complete courses infrastructure to the site with:
+
+1. **Content Management System**: Course and lesson data models, file-based content in markdown
+2. **Teaching Components**: Specialized UI components for technical education
+3. **Three-Level Navigation**: Courses list → Course overview → Individual lessons
+4. **Sample Content**: Two starter courses with initial lessons
+5. **Progress Tracking**: Visual indicators and lesson navigation
+
+### Key Features/Components
+
+**Course Library** (`src/lib/courses.ts`):
+- `Course` and `Lesson` TypeScript interfaces with frontmatter definitions
+- Functions to fetch courses, lessons, and adjacent lessons for navigation
+- Progress calculation utilities
+- Difficulty color mapping
+
+**Teaching Components** (7 components in `src/components/courses/`):
+
+1. **Terminal** - Interactive terminal display with:
+   - macOS-style window chrome with traffic light buttons
+   - Command line with optional prompt (`$`)
+   - Output section for command results
+   - Copy-to-clipboard functionality
+
+2. **Callout** - Contextual information boxes with variants:
+   - `info` (blue) - General information
+   - `warning` (yellow) - Cautions and warnings
+   - `tip` (green) - Helpful tips and best practices
+   - `danger` (red) - Critical warnings
+
+3. **CommandExplain** - Interactive command breakdown:
+   - Hover/click on command parts to see explanations
+   - Color-coded by type (command, flag, argument, option)
+   - Legend showing what each color represents
+
+4. **LessonNavigation** - Next/previous lesson buttons:
+   - Smart routing (back to course when at boundaries)
+   - Progress context ("Lesson X of Y")
+   - Completion indication on final lesson
+
+5. **CourseProgress** - Visual progress bar:
+   - Percentage and lesson count display
+   - Smooth animations
+   - Gradient fill (cyan to blue)
+
+6. **CourseSidebar** - Course outline navigation:
+   - Expandable/collapsible
+   - Current lesson highlighted
+   - Checkmarks for completed lessons
+   - Integrated progress bar
+
+7. **CourseMarkdownRenderer** - Extended markdown renderer:
+   - All standard markdown with course-specific styling
+   - Support for custom HTML components in markdown
+   - Enhanced code blocks and tables
+   - Callout shorthand tags (`<tip>`, `<warning>`, etc.)
+
+**Page Structure**:
+
+Three pages following Next.js App Router patterns:
+
+1. `/courses` - Course listing with difficulty badges, duration, lesson counts
+2. `/courses/[courseSlug]` - Course overview with syllabus sidebar
+3. `/courses/[courseSlug]/[lessonSlug]` - Lesson content with sidebar navigation
+
+## Implementation Details
+
+### Content Structure
+
+Courses stored in `public/courses/` with this hierarchy:
+
+```
+public/courses/
+├── practical-unix/
+│   ├── index.md           # Course metadata
+│   └── lessons/
+│       ├── 01-introduction.md
+│       └── 02-navigation.md
+└── terraform/
+    ├── index.md
+    └── lessons/
+        └── 01-introduction.md
+```
+
+### Frontmatter Schema
+
+**Course metadata**:
+```yaml
+---
+title: Practical Unix
+description: Master essential Unix commands...
+difficulty: beginner | intermediate | advanced
+duration: 4 hours
+tags: [unix, linux, command-line]
+status: draft | published
+---
+```
+
+**Lesson metadata**:
+```yaml
+---
+title: Getting Started with the Terminal
+order: 1
+duration: 15 min
+objectives:
+  - Understand what a shell is
+  - Run your first commands
+---
+```
+
+### Component Patterns
+
+**Terminal Component Example**:
+```tsx
+<Terminal 
+  command="ls -la /home" 
+  output="drwxr-xr-x 5 user staff 160 Dec 14 10:30 ."
+  title="List directory contents"
+/>
+```
+
+**Callout in Markdown**:
+```markdown
+<tip>
+Use tab completion to avoid typos and save time!
+</tip>
+```
+
+**Command Explanation**:
+```tsx
+<CommandExplain parts={[
+  { text: 'grep', explanation: 'Search for patterns', type: 'command' },
+  { text: '-r', explanation: 'Recursive search', type: 'flag' },
+  { text: 'pattern', explanation: 'Text to find', type: 'argument' }
+]} />
+```
+
+### Data Flow
+
+```
+Markdown files → courses.ts library → Page components → Teaching components
+                     ↓
+                State/Progress → Sidebar/Navigation
+```
+
+Static generation at build time:
+- `generateStaticParams()` creates routes for all courses/lessons
+- Content parsed once, cached in build artifacts
+- Fast page loads with no runtime markdown parsing
+
+### Design System Integration
+
+All components use existing design tokens:
+- Colors: cyan-400 primary, gray-300/400 text
+- Backgrounds: black/40 with backdrop blur
+- Borders: cyan-500/20 for subtle separation
+- Spacing: consistent with blog/talks patterns
+
+## Visual/UX Impact
+
+**Course Listing** (`/courses`):
+- Grid layout with course cards
+- Difficulty badges (color-coded: green/yellow/red)
+- Duration and lesson count badges
+- Featured images for courses
+- Hover effects with shadow and border color shift
+
+**Course Overview** (`/courses/[slug]`):
+- Hero section with course metadata
+- Markdown content area for course description
+- Sticky sidebar with:
+  - "Start Course" CTA button (gradient cyan-blue)
+  - Course stats (lessons, difficulty, duration)
+  - Full syllabus with clickable lesson list
+
+**Lesson Page** (`/courses/[slug]/[lesson]`):
+- Breadcrumb navigation showing course title
+- Progress bar in header (shows X of Y lessons)
+- Two-column layout:
+  - Main content area (lesson markdown)
+  - Sidebar with course outline
+- Learning objectives highlighted at top
+- Prev/Next navigation at bottom
+- Special "Completed!" state on final lesson
+
+**Interactive Elements**:
+- Terminal blocks with realistic styling
+- Callout boxes with icons and color coding
+- Hoverable command explanations
+- Smooth transitions and animations throughout
+
+## Sample Content
+
+### Practical Unix Course
+**Target Audience**: Developers new to command line
+**Difficulty**: Beginner
+**Content**:
+- Introduction: Shell basics, first commands, command structure
+- Navigation: Filesystem hierarchy, `cd`, `pwd`, `ls`, shortcuts
+
+Focus on practical, hands-on learning:
+- Real command examples
+- Common gotchas highlighted
+- Practice exercises
+- Tips from years of Unix experience
+
+### Terraform Course
+**Target Audience**: DevOps engineers starting with IaC
+**Difficulty**: Intermediate
+**Content**:
+- Introduction: What is Terraform, installation, first configuration, workflow (init/plan/apply)
+
+Focus on concepts and hands-on:
+- Simple local provider for learning without cloud costs
+- Understanding state management
+- Best practices from the start
+
+## Benefits
+
+**For Visitors**:
+- Structured learning path from beginner to advanced topics
+- Interactive examples they can copy and try
+- Visual feedback on progress through courses
+- Mobile-friendly responsive design
+- Fast page loads (static generation)
+
+**For Content Creation**:
+- Simple markdown-based authoring
+- Reusable components via custom tags
+- Consistent structure enforced by frontmatter
+- Easy to add new courses and lessons
+- Version controlled content
+
+**For Development**:
+- TypeScript types ensure data consistency
+- Component library enables rich interactions
+- Static generation = fast performance
+- Follows existing patterns (similar to blog/talks)
+- Easy to extend with new teaching components
+
+## Technical Implementation
+
+### Library Functions
+
+Key utilities in `courses.ts`:
+
+```typescript
+getAllCourses() → Course[]
+getCourse(slug) → Course | null
+getCourseLessons(courseSlug) → Lesson[]
+getLesson(courseSlug, lessonSlug) → Lesson | null
+getAdjacentLessons(courseSlug, lessonSlug) → { prev, next }
+getLessonProgress(lessons, currentSlug) → { current, total, percentage }
+getDifficultyColor(difficulty) → string
+```
+
+### Component Architecture
+
+**Terminal Component**:
+- Client component (`'use client'`)
+- Clipboard API for copy functionality
+- Conditional sections (header, command, output)
+- Accessible button with visual feedback
+
+**Callout Component**:
+- Variant-based styling (info/warning/tip/danger)
+- Icon mapping with lucide-react
+- Flexible children content
+- Default titles per variant
+
+**CourseSidebar**:
+- Collapsible with animation
+- Current lesson highlighted
+- Past lessons marked with checkmarks
+- Click to navigate to any lesson
+
+### Markdown Rendering
+
+Extended `react-markdown` with custom components:
+
+```typescript
+<ReactMarkdown
+  components={{
+    terminal: (props) => <Terminal {...props} />,
+    tip: (props) => <Callout variant="tip" {...props} />,
+    // ... other custom components
+  }}
+>
+  {content}
+</ReactMarkdown>
+```
+
+Supports both:
+- HTML tags in markdown: `<terminal command="ls" />`
+- Shorthand tags: `<tip>Use this approach</tip>`
+
+### Routing and Static Generation
+
+Next.js App Router patterns:
+
+```typescript
+// Generate static paths at build time
+export async function generateStaticParams() {
+  const courses = await getAllCourses();
+  return courses.map(course => ({
+    courseSlug: course.slug
+  }));
+}
+```
+
+All pages pre-rendered:
+- `/courses` - static
+- `/courses/practical-unix` - static
+- `/courses/practical-unix/01-introduction` - static
+- etc.
+
+## Build Output
+
+Successful build with all routes generated:
+
+```
+Route (app)
+├ ○ /courses
+├ ● /courses/[courseSlug]
+│   ├ /courses/practical-unix
+│   └ /courses/terraform
+└ ● /courses/[courseSlug]/[lessonSlug]
+    ├ /courses/practical-unix/01-introduction
+    ├ /courses/practical-unix/02-navigation
+    └ /courses/terraform/01-introduction
+
+○ (Static)  prerendered as static content
+● (SSG)     prerendered as static HTML
+```
+
+Total: 6 new static pages
+
+## Current Status
+
+**Implemented**:
+- ✅ Complete course infrastructure
+- ✅ All teaching components
+- ✅ Three-level page hierarchy
+- ✅ Course and lesson management
+- ✅ Two starter courses with lessons
+- ✅ Progress tracking
+- ✅ Navigation and sidebar
+- ✅ Responsive design
+- ✅ Build verification
+
+**Temporarily Disabled**:
+- ⏸️ "Courses" link removed from header navigation (will be re-added when content is ready)
+
+**Remaining Work**:
+- Additional lesson content for Practical Unix
+- Additional lesson content for Terraform
+- More courses as content develops
+- Potential enhancements:
+  - Quiz/assessment components
+  - Code playground integration
+  - Video embedding
+  - Completion tracking (localStorage)
+  - Certificate generation
+
+## Design Decisions
+
+**Why file-based content?**
+- Follows proven pattern from blog/talks
+- Easy to edit, version control, and review
+- Fast static generation
+- No database needed
+
+**Why custom markdown components?**
+- Standard markdown lacks interactive elements
+- Custom components provide richer learning experience
+- Extensible - can add more component types
+- Maintains content readability (looks like enhanced markdown)
+
+**Why three-level hierarchy?**
+- Scales well (courses → lessons → sections)
+- Matches mental model of online courses
+- Allows course overview before diving in
+- Easy navigation between related content
+
+**Why static generation?**
+- Fast page loads for learners
+- SEO friendly
+- No server runtime needed
+- Content rarely changes minute-to-minute
+
+**Why remove from navigation temporarily?**
+- Content still being developed
+- Better UX to launch with complete courses
+- Internal/preview access still works via direct URLs
+- Easy to re-enable by adding one line to nav array
+
+## Files Created
+
+**Library**:
+- `src/lib/courses.ts` (202 lines)
+
+**Components** (7 files, ~600 lines):
+- `src/components/courses/Terminal.tsx`
+- `src/components/courses/Callout.tsx`
+- `src/components/courses/CommandExplain.tsx`
+- `src/components/courses/LessonNavigation.tsx`
+- `src/components/courses/CourseProgress.tsx`
+- `src/components/courses/CourseSidebar.tsx`
+- `src/components/courses/CourseMarkdownRenderer.tsx`
+
+**Pages** (3 files, ~400 lines):
+- `src/app/courses/page.tsx`
+- `src/app/courses/[courseSlug]/page.tsx`
+- `src/app/courses/[courseSlug]/[lessonSlug]/page.tsx`
+
+**Content** (5 files):
+- `public/courses/practical-unix/index.md`
+- `public/courses/practical-unix/lessons/01-introduction.md`
+- `public/courses/practical-unix/lessons/02-navigation.md`
+- `public/courses/terraform/index.md`
+- `public/courses/terraform/lessons/01-introduction.md`
+
+**Modified**:
+- `src/components/Header.tsx` (added/removed "Courses" link)
+- `src/components/Home.jsx` (nav update - reverted)
+
+Total: **16 new files, ~1400 lines of code**
+
+## Impact
+
+**Content Creators**:
+- New medium for sharing knowledge
+- Structured format encourages thoroughness
+- Reusable components speed up lesson creation
+
+**Developers (Future)**:
+- Clean patterns to follow for new courses
+- Component library for technical content
+- Well-documented code structure
+
+**Site Visitors (When Launched)**:
+- New way to learn from practical, hands-on courses
+- Progress tracking keeps motivation high
+- Interactive elements aid understanding
+
+**Portfolio Impact**:
+- Demonstrates full-stack capability (content to component design)
+- Shows teaching/mentoring ability
+- Differentiates from typical developer portfolios
+
+## Related Work
+
+**Similar Patterns**:
+- Blog system (`src/app/blog/`, `src/lib/blog.ts`)
+- Talks system (`src/app/talks/`, `src/lib/talks.ts`)
+- Markdown rendering (`src/components/blog/MarkdownRenderer.tsx`)
+
+**Leveraged Components**:
+- UI library (`src/components/ui/`) for buttons, etc.
+- Design tokens (colors, spacing) from existing system
+- Layout patterns (header, navigation) consistent site-wide
+
+**Future Connections**:
+- Could link blog posts to relevant course lessons
+- Could reference course concepts in talks
+- Could create "learning paths" across all content types
+
+## Future Enhancements
+
+**Content**:
+- Complete Practical Unix (file operations, text processing, pipes, scripting)
+- Complete Terraform (providers, resources, modules, state, best practices)
+- New courses: Kubernetes, Docker, CI/CD, Cloud platforms
+
+**Features**:
+- Code playgrounds (embed sandboxes for safe experimentation)
+- Video integration (complement lessons with recorded demos)
+- Quizzes/assessments (test understanding)
+- Progress persistence (track completion across sessions)
+- Course completion certificates
+- Discussion/comments per lesson
+- Search across course content
+- Course recommendations based on skill level
+- Dark/light mode toggle (currently dark only)
+
+**Analytics**:
+- Track which lessons are most viewed
+- Identify where learners drop off
+- Measure time spent on lessons
+- A/B test different teaching approaches
+
+## Lessons Learned
+
+**Component Design**:
+- Interactive components need both visual and keyboard accessibility
+- Reusable components need flexible APIs (props for all customization)
+- Copy-to-clipboard is essential for code examples
+
+**Content Structure**:
+- Frontmatter enforces consistency
+- Order field better than relying on file naming
+- Objectives at lesson start set clear expectations
+
+**Technical**:
+- Static generation works great for educational content
+- TypeScript types catch data inconsistencies early
+- Following existing patterns speeds development
+
+**UX**:
+- Progress indicators motivate completion
+- Sidebar navigation prevents getting lost
+- Interactive elements (hover, click) increase engagement
+
+---
+
+**Status**: ✅ Implemented (hidden from navigation until content complete)
+
+**Next Steps**: Create additional lesson content to complete initial course offerings, then re-enable navigation link to publicly launch courses section.

--- a/public/courses/practical-unix/index.md
+++ b/public/courses/practical-unix/index.md
@@ -1,0 +1,47 @@
+---
+title: Practical Unix
+description: Master essential Unix commands and concepts that every developer needs. From navigating the filesystem to text processing and shell scripting basics.
+difficulty: beginner
+duration: 4 hours
+tags:
+  - unix
+  - linux
+  - command-line
+  - shell
+  - terminal
+status: published
+---
+
+## Why Learn Unix?
+
+Every server, container, and cloud instance runs some flavor of Unix. Whether you're debugging a production issue at 2 AM, automating deployments, or just trying to be more productive, Unix skills are non-negotiable.
+
+This course focuses on **practical skills** you'll use daily:
+
+- Navigate and manipulate the filesystem with confidence
+- Process text and logs efficiently
+- Chain commands together with pipes
+- Write simple shell scripts to automate tasks
+
+## Who Is This For?
+
+- Developers who want to level up their terminal skills
+- DevOps engineers starting their journey
+- Anyone who's been meaning to "really learn" the command line
+
+## Prerequisites
+
+- Access to a Unix-like environment (macOS, Linux, or WSL on Windows)
+- Basic familiarity with opening a terminal
+- Curiosity and willingness to practice
+
+## What You'll Build
+
+By the end of this course, you'll be comfortable:
+
+- Moving around the filesystem without thinking
+- Finding files and searching through logs
+- Processing and transforming text data
+- Automating repetitive tasks with scripts
+
+Let's get started!

--- a/public/courses/practical-unix/lessons/01-introduction.md
+++ b/public/courses/practical-unix/lessons/01-introduction.md
@@ -1,0 +1,113 @@
+---
+title: Getting Started with the Terminal
+order: 1
+duration: 15 min
+objectives:
+  - Understand what a shell is and why it matters
+  - Open and navigate your terminal application
+  - Run your first commands
+  - Understand command structure and arguments
+---
+
+## What Is a Shell?
+
+A **shell** is a program that interprets your commands and communicates with the operating system. When you open a terminal, you're interacting with a shell.
+
+The most common shells are:
+
+- **Bash** (Bourne Again Shell) - The default on most Linux systems
+- **Zsh** - The default on macOS (since Catalina)
+- **Fish** - A modern, user-friendly alternative
+
+For this course, we'll focus on concepts that work across all shells.
+
+## Your First Commands
+
+Let's start with the basics. Open your terminal and try these:
+
+```bash
+whoami
+```
+
+This displays your username. Simple, but it confirms your terminal is working.
+
+```bash
+date
+```
+
+Shows the current date and time. Notice how commands just... run? No clicking, no menus.
+
+```bash
+echo "Hello, Unix!"
+```
+
+The `echo` command prints text to the screen. We'll use this a lot for debugging and scripting.
+
+## Understanding Command Structure
+
+Unix commands follow a consistent pattern:
+
+```
+command [options] [arguments]
+```
+
+Let's break this down:
+
+- **command** - The program you want to run (e.g., `ls`, `cat`, `grep`)
+- **options** - Modify how the command behaves (usually start with `-` or `--`)
+- **arguments** - What the command operates on (files, directories, text)
+
+### Example: The `ls` Command
+
+```bash
+ls
+```
+
+Lists files in the current directory.
+
+```bash
+ls -l
+```
+
+The `-l` option shows a "long" format with details like permissions, size, and dates.
+
+```bash
+ls -la /home
+```
+
+Here we combine options (`-l` and `-a` for "all", including hidden files) and provide an argument (`/home` directory).
+
+<tip>
+Most commands have a `--help` option that shows available options. Try `ls --help` to see all the things `ls` can do!
+</tip>
+
+## The Manual Pages
+
+Unix has built-in documentation called "man pages" (short for manual):
+
+```bash
+man ls
+```
+
+This opens the full documentation for `ls`. Use arrow keys to scroll, and press `q` to quit.
+
+<info>
+Man pages can be overwhelming at first. Focus on the DESCRIPTION and EXAMPLES sections. The rest will make sense as you learn more.
+</info>
+
+## Practice Exercise
+
+Try these commands and observe the output:
+
+1. Run `pwd` - What does it show?
+2. Run `ls -la` in your home directory
+3. Run `man echo` and find out what the `-n` option does
+
+## Key Takeaways
+
+- The shell is your interface to the operating system
+- Commands follow the pattern: `command [options] [arguments]`
+- Use `--help` or `man` to learn about any command
+- Practice is the only way to get comfortable
+
+In the next lesson, we'll dive into navigating the filesystem.

--- a/public/courses/practical-unix/lessons/02-navigation.md
+++ b/public/courses/practical-unix/lessons/02-navigation.md
@@ -1,0 +1,184 @@
+---
+title: Navigating the Filesystem
+order: 2
+duration: 20 min
+objectives:
+  - Understand the Unix filesystem hierarchy
+  - Navigate between directories with cd
+  - Use absolute and relative paths
+  - Master shortcuts like ~ and ..
+---
+
+## The Filesystem Tree
+
+Unix organizes everything in a tree structure starting from the **root** directory `/`. Everything - files, directories, devices, even running processes - lives somewhere in this tree.
+
+```
+/
+├── home/          # User home directories
+│   └── swarup/    # Your stuff lives here
+├── etc/           # System configuration
+├── var/           # Variable data (logs, databases)
+├── usr/           # User programs and utilities
+├── tmp/           # Temporary files
+└── bin/           # Essential command binaries
+```
+
+<info>
+Unlike Windows with its `C:\`, `D:\` drive letters, Unix has a single unified tree. External drives get "mounted" into this tree as directories.
+</info>
+
+## Where Am I? (`pwd`)
+
+The `pwd` command (print working directory) tells you your current location:
+
+```bash
+pwd
+```
+
+You'll see something like `/home/swarup` or `/Users/swarup` on macOS.
+
+## Moving Around (`cd`)
+
+The `cd` command (change directory) moves you around:
+
+```bash
+cd /var/log
+pwd
+```
+
+You're now in the system logs directory.
+
+### Absolute vs Relative Paths
+
+**Absolute paths** start from root (`/`):
+
+```bash
+cd /home/swarup/projects
+```
+
+**Relative paths** start from your current location:
+
+```bash
+cd projects/website
+```
+
+If you're in `/home/swarup`, this takes you to `/home/swarup/projects/website`.
+
+## Essential Shortcuts
+
+These shortcuts will save you thousands of keystrokes:
+
+| Shortcut | Meaning |
+|----------|---------|
+| `~` | Your home directory |
+| `.` | Current directory |
+| `..` | Parent directory |
+| `-` | Previous directory |
+
+### Examples
+
+```bash
+cd ~
+```
+
+Go home, no matter where you are.
+
+```bash
+cd ..
+```
+
+Go up one level.
+
+```bash
+cd ../..
+```
+
+Go up two levels.
+
+```bash
+cd -
+```
+
+Toggle between current and previous directory. Super useful!
+
+<tip>
+Combine these! `cd ~/projects` takes you to the projects folder in your home directory from anywhere.
+</tip>
+
+## Listing Contents (`ls`)
+
+We saw `ls` briefly. Let's explore it more:
+
+```bash
+ls
+```
+
+Basic listing.
+
+```bash
+ls -l
+```
+
+Long format with details.
+
+```bash
+ls -la
+```
+
+Long format including hidden files (those starting with `.`).
+
+```bash
+ls -lh
+```
+
+Long format with human-readable sizes (KB, MB, GB instead of bytes).
+
+### Understanding `ls -l` Output
+
+```
+drwxr-xr-x  5 swarup staff  160 Dec 14 10:30 projects
+-rw-r--r--  1 swarup staff 1234 Dec 14 09:15 notes.txt
+```
+
+| Part | Meaning |
+|------|---------|
+| `d` or `-` | Directory or file |
+| `rwxr-xr-x` | Permissions (we'll cover this later) |
+| `5` or `1` | Number of links |
+| `swarup` | Owner |
+| `staff` | Group |
+| `160` | Size in bytes |
+| `Dec 14 10:30` | Last modified |
+| `projects` | Name |
+
+## Tab Completion
+
+This is a game-changer. Start typing a path and press `Tab`:
+
+```bash
+cd ~/Doc<Tab>
+```
+
+The shell completes it to `~/Documents/`. If there are multiple matches, press Tab twice to see options.
+
+<warning>
+Tab completion is your friend. If it doesn't complete, either the path doesn't exist or you need to type more characters to disambiguate.
+</warning>
+
+## Practice Exercise
+
+1. Navigate to your home directory
+2. Create a mental map: run `ls -la` and identify hidden files (hint: they start with `.`)
+3. Navigate to `/var/log` and back home using `cd -`
+4. Try tab-completing a long path
+
+## Key Takeaways
+
+- The filesystem is a tree starting at `/`
+- `pwd` shows where you are, `cd` moves you around
+- Use `~`, `..`, and `-` to navigate efficiently
+- Tab completion saves time and prevents typos
+- `ls -la` is your go-to for seeing what's in a directory
+
+Next up: creating, copying, and moving files.

--- a/public/courses/terraform/index.md
+++ b/public/courses/terraform/index.md
@@ -1,0 +1,56 @@
+---
+title: Terraform Fundamentals
+description: Learn Infrastructure as Code with Terraform. Define, provision, and manage cloud resources using declarative configuration files.
+difficulty: intermediate
+duration: 6 hours
+tags:
+  - terraform
+  - infrastructure-as-code
+  - devops
+  - cloud
+  - aws
+status: published
+---
+
+## What Is Terraform?
+
+Terraform is an **Infrastructure as Code (IaC)** tool that lets you define cloud resources in human-readable configuration files. Instead of clicking through cloud consoles, you write code that describes your infrastructure, and Terraform makes it real.
+
+## Why Infrastructure as Code?
+
+Traditional infrastructure management has problems:
+
+- **Inconsistency** - Manual changes lead to drift between environments
+- **No history** - Who changed what, when, and why?
+- **Slow recovery** - Rebuilding infrastructure manually is painful
+- **Knowledge silos** - Only certain people know how things are set up
+
+IaC solves these by treating infrastructure like software:
+
+- Version controlled
+- Peer reviewed
+- Reproducible
+- Self-documenting
+
+## What You'll Learn
+
+This course covers Terraform fundamentals:
+
+- HCL (HashiCorp Configuration Language) syntax
+- Providers and resources
+- Variables and outputs
+- State management
+- Modules for reusability
+
+## Prerequisites
+
+- Basic command-line skills (see the Unix course if needed)
+- An AWS account (free tier works fine)
+- Terraform installed locally
+- A code editor (VS Code with Terraform extension recommended)
+
+## Course Structure
+
+We'll build real infrastructure as we learn, starting with simple resources and progressing to production-ready patterns.
+
+Let's begin!

--- a/public/courses/terraform/lessons/01-introduction.md
+++ b/public/courses/terraform/lessons/01-introduction.md
@@ -1,0 +1,192 @@
+---
+title: Introduction to Terraform
+order: 1
+duration: 20 min
+objectives:
+  - Understand what Terraform does and how it works
+  - Install Terraform on your machine
+  - Write your first Terraform configuration
+  - Run terraform init, plan, and apply
+---
+
+## How Terraform Works
+
+Terraform follows a simple workflow:
+
+1. **Write** - Define resources in `.tf` files
+2. **Plan** - Preview what Terraform will do
+3. **Apply** - Create, update, or delete resources
+4. **Destroy** - Clean up when done
+
+Under the hood, Terraform:
+
+- Reads your configuration files
+- Compares desired state to actual state
+- Calculates the minimal set of changes needed
+- Executes those changes via cloud provider APIs
+
+<info>
+Terraform is **declarative**. You describe what you want, not how to create it. Terraform figures out the "how" for you.
+</info>
+
+## Installing Terraform
+
+### macOS (with Homebrew)
+
+```bash
+brew tap hashicorp/tap
+brew install hashicorp/tap/terraform
+```
+
+### Linux
+
+```bash
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install terraform
+```
+
+### Verify Installation
+
+```bash
+terraform version
+```
+
+You should see output like:
+
+```
+Terraform v1.6.0
+on darwin_arm64
+```
+
+## Your First Configuration
+
+Create a new directory and file:
+
+```bash
+mkdir terraform-intro && cd terraform-intro
+```
+
+Create `main.tf` with this content:
+
+```hcl
+terraform {
+  required_providers {
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+}
+
+resource "local_file" "hello" {
+  content  = "Hello, Terraform!"
+  filename = "${path.module}/hello.txt"
+}
+```
+
+This configuration uses the `local` provider to create a file. It's perfect for learning without needing cloud credentials.
+
+## The Terraform Workflow
+
+### Step 1: Initialize
+
+```bash
+terraform init
+```
+
+This downloads the required providers and sets up your working directory.
+
+### Step 2: Plan
+
+```bash
+terraform plan
+```
+
+Terraform shows you what it will do:
+
+```
+Terraform will perform the following actions:
+
+  # local_file.hello will be created
+  + resource "local_file" "hello" {
+      + content  = "Hello, Terraform!"
+      + filename = "./hello.txt"
+      + id       = (known after apply)
+    }
+
+Plan: 1 to add, 0 to change, 0 to destroy.
+```
+
+<tip>
+Always review the plan before applying! In production, this prevents accidental destruction of resources.
+</tip>
+
+### Step 3: Apply
+
+```bash
+terraform apply
+```
+
+Terraform asks for confirmation, then creates the resource:
+
+```
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+
+local_file.hello: Creating...
+local_file.hello: Creation complete after 0s [id=...]
+
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+```
+
+Check your directory - `hello.txt` now exists!
+
+```bash
+cat hello.txt
+```
+
+### Step 4: Destroy (When Done)
+
+```bash
+terraform destroy
+```
+
+This removes all resources managed by this configuration.
+
+<warning>
+Be careful with `terraform destroy` in production! It will delete real infrastructure.
+</warning>
+
+## Understanding State
+
+Terraform keeps track of what it manages in a **state file** (`terraform.tfstate`). This file maps your configuration to real resources.
+
+```bash
+cat terraform.tfstate
+```
+
+You'll see JSON describing the resources Terraform created.
+
+<danger>
+Never manually edit the state file! Use `terraform state` commands if you need to modify state.
+</danger>
+
+## Practice Exercise
+
+1. Modify `main.tf` to change the file content
+2. Run `terraform plan` - what does it show?
+3. Run `terraform apply` to update the file
+4. Clean up with `terraform destroy`
+
+## Key Takeaways
+
+- Terraform is declarative: describe what you want, not how to build it
+- The workflow is: init → plan → apply → (eventually) destroy
+- State tracks the mapping between config and real resources
+- Always review plans before applying
+
+Next, we'll learn about providers and resources in depth.

--- a/public/fastlane/2026-01-21-the-platform-that-shouldnt-exist.md
+++ b/public/fastlane/2026-01-21-the-platform-that-shouldnt-exist.md
@@ -1,0 +1,132 @@
+---
+title: "The Platform That Shouldn't Exist"
+date: "2026-01-21"
+tags: ["planton", "startup", "reflection"]
+---
+
+I had a conversation with three Gemini models last night out of pure curiosity. I wanted to understand: why were we able to build such a platform when someone else with more resources wouldn't have already built it—given how big of a deal this is for organizations across the globe?
+
+The answer might come down to a unique combination of factors. Not everyone who has the level of expertise I do at the ground level—doing these hard things every day, collaborating with developers—also has full-stack development experience and the passion to build a product. There might be people as obsessed about this problem as I am, but those people may not have the opportunity or desire to build a startup.
+
+It's a lot of things coming together.
+
+I've decided not to approach this with imposter syndrome. I don't want to feel like "maybe I'm not the guy who should have built this kind of thing." I want to start believing that we indeed built a platform that doesn't exist anywhere else. It's been almost two and a half years in development. It is extremely complicated to build, but we did it. And it checks a lot of boxes.
+
+The market research confirmed what I suspected: Internal Developer Platforms are projected to be a $7.8 billion market by 2033. Gartner says 80% of software engineering organizations will establish platform teams by 2026. The problem is real, the market is desperate for a solution, and most existing tools are just "Kubernetes wrappers" that don't solve the actual problem.
+
+We built something different. Not because we're smarter, but because we had the right combination of expertise, experience, obsession, and opportunity.
+
+---
+
+## Here is the conversation
+
+**Me:**
+
+Why isn't there a single DevOps automation platform that allows anyone to deploy infrastructure and applications to any cloud provider? Like, why isn't there something as simple as GitHub to push code, but for deploying any cloud infrastructure with a unified interface?
+
+The platform should provide a Vercel-like backend experience for services deploying to the customer's own cloud account. Same experience on any cloud and any target platform—whether it's Cloud Run, ECS, Kubernetes, or even deploying databases and message queues on Kubernetes.
+
+It would be super useful for developers to move fast, right? Are there any platforms like this at all?
+
+**Gemini:**
+
+You're describing the "Holy Grail" of DevOps: a **Universal Control Plane**. It feels like a massive gap—we have "one-click" deploys for frontends (Vercel, Netlify) and "push-to-deploy" for code (GitHub), but backend infrastructure remains a complex mess of YAML files, cloud-specific consoles, and fragmented tools.
+
+**The short answer:** While no perfect single standard exists yet, a new category called **BYOC (Bring Your Own Cloud) PaaS** has emerged to solve exactly this problem. These platforms provide a Vercel-like dashboard but deploy into *your* AWS/GCP account. You own the data and the cloud bill; they provide the "Easy Button."
+
+However, the reason a "single platform" doesn't dominate yet comes down to fundamental hurdles:
+
+**Why It's So Hard to Build:**
+
+1. **The "Lowest Common Denominator" Problem** - AWS has "ALB" load balancers, Google has "Global Forwarding Rules," Azure has "App Gateway." A unified tool can only expose features they all share, meaning you lose 50% of each cloud's power.
+
+2. **Leaky Abstractions** - When things work, it's magic. When they break, you get errors like `AWS IAM Role Arn:aws:iam::12345 cannot assume role due to Trust Policy constraint`. Suddenly you need to be an AWS expert to debug the "simple" tool.
+
+3. **The Networking Spiderweb** - It's not just about code—it's VPCs, Subnets, IAM roles, Load Balancers. GCP Cloud Run is request-driven (scales to zero), while AWS ECS is resource-driven (stays running). Unifying these requires complex translation layers.
+
+4. **The Velocity Problem** - AWS releases hundreds of new features per year. A third-party platform has to constantly chase three different giants moving in different directions.
+
+5. **The Security Wall** - To provide a "Vercel experience" on your account, the platform needs deep access to your IAM, networking, and VPCs. Managing that securely across thousands of customers is a massive liability.
+
+6. **Business Incentives** - Cloud providers want vendor lock-in. They have zero incentive to support a standard "Deploy Button" that makes it easy to switch clouds.
+
+**Current Landscape:**
+
+There are platforms trying to solve this problem today. Here's what exists:
+
+**Camp A: "Interface Only" Platforms**
+- **Backstage** - Spotify's open-source IDP portal. Creates a catalog where developers click "Create Service," but it triggers scripts you write. Safe for enterprises (no cloud access needed), but you still build the engine yourself.
+- **Port** - Similar to Backstage. Provides the unified dashboard, you provide the automation.
+- **Cortex** - Another IDP catalog tool focused on service ownership and documentation.
+- **Humanitec** - Platform orchestrator that sits on top of your existing tools.
+
+**Camp B: "Universal Deployers" (BYOC Platforms)**
+- **Zeet** - Connects to AWS/GCP/Azure/DigitalOcean. Supports K8s, ECS, Cloud Run, and Lambda. Closest to true multi-cloud, multi-target flexibility.
+- **Qovery** - Turns a Kubernetes cluster into "Heroku" on your cloud account. Strong on preview environments (full infrastructure copy for every PR). AWS, Azure, GCP, Scaleway support.
+- **Northflank** - Polished UI for deploying containers, builds, and managed databases. Excellent support for stateful workloads (DBs, Redis, MinIO). AWS/GCP/Azure.
+- **Porter** - Kubernetes-native but hidden. Sets up and manages K8s clusters in your account, gives you a Heroku-like experience on top. AWS/GCP/Azure.
+- **Flightcontrol** - AWS-only, ECS/Fargate focused. By restricting to AWS, avoids the "lowest common denominator" problem. Best UX for pure AWS deployments.
+
+**IaC & Framework Tools**
+- **Crossplane** - Turns your Kubernetes cluster into a "universal control plane" that can provision resources from any cloud using K8s manifests. Framework for building your own platform, not a ready-made product.
+- **Pulumi** - Infrastructure-as-Code using real programming languages (TypeScript, Python, Go). Not a platform with UI, but the only code-based way to deploy to ECS and Cloud Run using the same language.
+
+**Backend-as-a-Service (Alternative Approach)**
+- **Supabase** - Postgres, Auth, Storage as a service. Can be self-hosted on your own infrastructure.
+- **Appwrite** - Backend functions, databases, auth unified. Hosted or self-hosted.
+- **Railway** - Simple "push to deploy" for backends, but hosted on their infrastructure (not BYOC).
+- **Render** - Similar to Railway—simple deploys but on their cloud, not yours.
+
+**Niche/Emerging**
+- **Coherence** - Abstracts Cloud Run and ECS with YAML config files.
+- **Kuberns** - AI-driven automation, primarily AWS in 2026.
+
+**The Pattern:**
+
+Two camps exist because the market is fighting over *how* to solve it:
+- Camp A is safe but requires you to build the deployment engine
+- Camp B does the actual work but needs admin access to your cloud accounts (trust barrier)
+
+**The Kubernetes Problem:**
+
+Most Camp B platforms are essentially "Kubernetes wrappers." They hide K8s complexity but force you to pay the "K8s Tax"—high base costs, slow startup times, rigid networking. Very few support ECS and Cloud Run as first-class citizens without hidden Kubernetes underneath.
+
+**Me:**
+
+If a platform that does what I described exists, would it find good market traction? Assuming incredible UX. Be honest.
+
+**Gemini:**
+
+**Yes, absolutely.** In fact, this is one of the hottest and fastest-growing sectors in tech. It's called **Platform Engineering**.
+
+Gartner predicts that **by 2026, 80% of software engineering organizations** will establish platform teams to build exactly what you're describing. The demand is massive:
+
+**Why the Market Traction Would Be Astronomical:**
+
+1. **The Talent Gap** - Finding engineers who are great at both React/Node and Kubernetes/IAM/VPC-Peering is like finding a unicorn. A platform that removes this requirement lets companies hire 5 "Product Devs" instead of 4 Devs + 1 expensive DevOps Engineer.
+
+2. **The Market Size** - Internal Developer Portals (IDPs) are projected to be a **$7.8 billion market by 2033**.
+
+3. **The Multi-Cloud Pressure** - Regulatory requirements (especially in EU with DORA and Gaia-X) are forcing companies to prove they aren't locked into AWS. A platform that makes switching clouds as easy as a dropdown would be an instant buy for every CTO in Fintech and Healthcare.
+
+4. **The Shift Happening** - Moving from "DevOps" (you build it, you run it, you suffer) to "Platform Engineering" (the platform team builds the 'Golden Path', you just drive).
+
+**The Brutal Obstacles:**
+
+Even with incredible UX, you'd face three challenges that have killed many startups:
+
+1. **The "Black Box" Trust Issue** - Senior Architects are terrified of "Magic." To win, your platform must be "ejectable"—it must write clean, standard code (Terraform/Pulumi) into the user's account that they can take over if your company disappears.
+
+2. **The Pricing "Double-Tax"** - Users hate paying twice. At $1M/year cloud spend, a 20% platform fee is $200k/year—the price of a full-time DevOps engineer. Most platforms struggle because they become more expensive than hiring someone.
+
+3. **The "90/10" Customization Trap** - 90% of apps are easy (container + DB + cache). But the last 10% (custom VPC peering, GPU clusters, LDAP integration) makes or breaks enterprise deals. If your platform says "No," teams abandon it.
+
+**The Verdict:**
+
+If you built this today with **AI-driven troubleshooting** (the platform doesn't just fail—it uses an LLM to explain *why* the AWS IAM role failed and fixes it in natural language), you'd likely lead the next generation of DevOps.
+
+The market is desperate for it. The "Single Platform" is inevitable. Cloud providers are becoming "Utilities" (like electricity), and platforms will become the "Appliances" developers actually interact with.
+
+Companies realize they can't replicate Vercel's UX by hiring 50 DevOps engineers. It's cheaper to pay for a platform than to build a bad internal version with Jenkins and Terraform.
+
+**This is not a question of "if" but "when" and "who."**

--- a/public/fastlane/2026-01-21-why-i-named-it-fastlane.md
+++ b/public/fastlane/2026-01-21-why-i-named-it-fastlane.md
@@ -1,0 +1,15 @@
+---
+title: "Why I Named It Fastlane"
+date: "2026-01-21"
+tags: ["reflection", "personal"]
+---
+
+I'm a huge fan of "The Millionaire Fastlane" by MJ DeMarco. The book shaped how I think about building wealth and living intentionally. It's about choosing the fast lane - not the slow lane of trading time for money, but the lane where you build systems, create value, and accelerate.
+
+That's why I named this space Fastlane. It represents the lane I've chosen for my life.
+
+But here's my own concept that I've been thinking about: life is single-threaded. Every day you wake up, you're on the same lane as yesterday. No branching, no parallel paths. No multithreading. Just you, moving forward, one day at a time. The only variables are your speed and direction.
+
+This space is my personal lane - a continuous stream of thoughts, observations, and moments captured as they happen. Not polished blog posts. Not curated content. Just authentic captures of what's on my mind.
+
+There's no navigation link to this page. If you're reading this, you found it. Welcome to my lane.

--- a/public/fastlane/README.md
+++ b/public/fastlane/README.md
@@ -1,0 +1,54 @@
+# Fastlane
+
+Life's single-threaded stream.
+
+## What is Fastlane?
+
+Fastlane is a personal timeline - a place to capture day-to-day thoughts, moments, and observations. Unlike polished blog posts, Fastlane entries are quick captures of what's on my mind.
+
+The name comes from "The Millionaire Fastlane" by MJ DeMarco - a book about choosing the fast lane in life, building systems, and accelerating toward your goals. I'm a huge fan, and this space represents the lane I've chosen.
+
+I also think of life as single-threaded - every day you wake up on the same lane as yesterday, no branching, no parallel paths. Just forward motion. This is my personal lane.
+
+## Access
+
+Navigate to `/fastlane` - there's no navigation link. If you're here, you found it.
+
+## Creating Entries
+
+Each entry is a markdown file with minimal frontmatter:
+
+```yaml
+---
+title: "Your title here"
+date: "YYYY-MM-DD"
+tags: ["optional", "tags"]  # Optional
+---
+
+Your content here...
+```
+
+### File Naming Convention
+
+Files follow the pattern: `YYYY-MM-DD-slug.md`
+
+Example: `2026-01-21-building-in-public.md`
+
+The date prefix ensures chronological ordering in the filesystem while the slug becomes the URL path.
+
+## Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Entry title |
+| `date` | Yes | Publication date (YYYY-MM-DD) |
+| `tags` | No | Array of lowercase tags |
+
+**Note:** Unlike blog posts, `excerpt`, `featured_image`, and `author` are not required. Excerpts are auto-generated from content.
+
+## Philosophy
+
+- **Quick to create** - Minimal friction for capturing thoughts
+- **Authentic voice** - No need for polish or structure
+- **Chronological** - Sorted by date, newest first
+- **Discoverable but not advertised** - No navigation link, accessed directly

--- a/public/talks/2025-11-29-hyderabad-cncf-meetup/index.md
+++ b/public/talks/2025-11-29-hyderabad-cncf-meetup/index.md
@@ -82,7 +82,7 @@ You can have unified experience without hiding provider differences. The manifes
 
 ## Links
 
-- **GitHub:** [github.com/project-planton/project-planton](https://github.com/project-planton/project-planton)
+- **GitHub:** [github.com/plantonhq/project-planton](https://github.com/plantonhq/project-planton)
 - **Website:** [project-planton.org](https://project-planton.org)
 
 ## About the Speaker
@@ -92,7 +92,7 @@ You can have unified experience without hiding provider differences. The manifes
 With 10+ years architecting DevOps infrastructure at scale, he believes in "consistency without abstraction": providing unified developer experience while preserving provider-specific power. His work focuses on making enterprise-grade platform engineering accessible to teams of all sizes through validation-first deployments, Protocol Buffers-based APIs, and the 80/20 principle applied to infrastructure.
 
 **Connect:**
-- **GitHub:** [github.com/project-planton/project-planton](https://github.com/project-planton/project-planton)
+- **GitHub:** [github.com/plantonhq/project-planton](https://github.com/plantonhq/project-planton)
 - **Website:** [project-planton.org](https://project-planton.org)
 - **LinkedIn:** [linkedin.com/in/swarupdonepudi](https://linkedin.com/in/swarupdonepudi)
 

--- a/public/talks/2025-11-29-hyderabad-cncf-meetup/organizer.md
+++ b/public/talks/2025-11-29-hyderabad-cncf-meetup/organizer.md
@@ -18,14 +18,14 @@ With over 10 years of experience in DevOps and platform engineering, Swarup has 
 
 Project Planton features 100+ deployment components with dual Pulumi/Terraform support, enabling teams to deploy production-ready infrastructure in minutes instead of weeks. PlantonCloud currently serves paying customers in production.
 
-**GitHub:** github.com/project-planton/project-planton  
+**GitHub:** github.com/plantonhq/project-planton  
 **Website:** project-planton.org
 
 ### Alternate Bio (More Concise)
 
 **Swarup Donepudi** is a platform engineering entrepreneur and creator of Project Planton, an open-source multi-cloud framework that brings Kubernetes Resource Model patterns to infrastructure deployments across any cloud provider. With a decade of DevOps experience, he's passionate about making enterprise-grade platform engineering accessible to teams of all sizes through "consistency without abstraction"—unified developer experience while preserving provider-specific power. He's currently preparing to launch Project Planton publicly and serves production customers through PlantonCloud.
 
-**GitHub:** github.com/project-planton/project-planton
+**GitHub:** github.com/plantonhq/project-planton
 
 ### Ultra-Short Bio (If space is limited)
 
@@ -178,7 +178,7 @@ The talk includes:
 - Open to connecting attendees with relevant resources
 
 ### Materials to Share
-- **GitHub:** github.com/project-planton/project-planton
+- **GitHub:** github.com/plantonhq/project-planton
 - **Website:** project-planton.org
 - **LinkedIn:** linkedin.com/in/swarupdonepudi
 

--- a/src/app/courses/[courseSlug]/[lessonSlug]/page.tsx
+++ b/src/app/courses/[courseSlug]/[lessonSlug]/page.tsx
@@ -1,0 +1,192 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  getAllCourses,
+  getCourse,
+  getCourseLessons,
+  getLesson,
+  getAdjacentLessons,
+  getLessonProgress,
+} from '@/lib/courses';
+import Header from '@/components/Header';
+import CourseMarkdownRenderer from '@/components/courses/CourseMarkdownRenderer';
+import CourseSidebar from '@/components/courses/CourseSidebar';
+import LessonNavigation from '@/components/courses/LessonNavigation';
+import CourseProgress from '@/components/courses/CourseProgress';
+import { ArrowLeft, Clock, Target } from 'lucide-react';
+
+interface LessonPageProps {
+  params: {
+    courseSlug: string;
+    lessonSlug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const courses = await getAllCourses();
+  const params: { courseSlug: string; lessonSlug: string }[] = [];
+
+  for (const course of courses) {
+    const lessons = await getCourseLessons(course.slug);
+    for (const lesson of lessons) {
+      params.push({
+        courseSlug: course.slug,
+        lessonSlug: lesson.slug,
+      });
+    }
+  }
+
+  return params;
+}
+
+export async function generateMetadata({
+  params,
+}: LessonPageProps): Promise<Metadata> {
+  const course = await getCourse(params.courseSlug);
+  const lesson = await getLesson(params.courseSlug, params.lessonSlug);
+
+  if (!course || !lesson) {
+    return {
+      title: 'Lesson Not Found',
+    };
+  }
+
+  return {
+    title: `${lesson.frontmatter.title} | ${course.frontmatter.title}`,
+    description: lesson.frontmatter.objectives?.[0] || course.frontmatter.description,
+  };
+}
+
+export default async function LessonPage({ params }: LessonPageProps) {
+  const course = await getCourse(params.courseSlug);
+  const lesson = await getLesson(params.courseSlug, params.lessonSlug);
+
+  if (!course || !lesson) {
+    notFound();
+  }
+
+  const lessons = await getCourseLessons(params.courseSlug);
+  const { prev, next } = await getAdjacentLessons(
+    params.courseSlug,
+    params.lessonSlug
+  );
+  const progress = getLessonProgress(lessons, params.lessonSlug);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 via-black to-gray-900">
+      <Header />
+
+      {/* Back link and progress */}
+      <div className="pt-20 border-b border-cyan-500/20">
+        <div className="container mx-auto px-4 py-4 max-w-7xl">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <Link
+              href={`/courses/${params.courseSlug}`}
+              className="inline-flex items-center gap-2 text-sm font-medium text-gray-400 hover:text-cyan-400 transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              {course.frontmatter.title}
+            </Link>
+            <div className="w-full sm:w-64">
+              <CourseProgress
+                current={progress.current}
+                total={progress.total}
+                size="sm"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Lesson content */}
+      <div className="container mx-auto px-4 py-8 max-w-7xl">
+        <div className="grid lg:grid-cols-4 gap-8">
+          {/* Sidebar */}
+          <div className="lg:col-span-1 order-2 lg:order-1">
+            <div className="lg:sticky lg:top-24">
+              <CourseSidebar
+                courseSlug={params.courseSlug}
+                courseTitle={course.frontmatter.title}
+                lessons={lessons.map((l) => ({
+                  slug: l.slug,
+                  title: l.frontmatter.title,
+                  duration: l.frontmatter.duration,
+                  order: l.frontmatter.order,
+                }))}
+                currentLessonSlug={params.lessonSlug}
+              />
+            </div>
+          </div>
+
+          {/* Main content */}
+          <div className="lg:col-span-3 order-1 lg:order-2">
+            <article className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg shadow-sm p-6 md:p-10">
+              {/* Lesson header */}
+              <header className="mb-8 pb-6 border-b border-cyan-500/20">
+                <div className="flex items-center gap-2 text-sm text-gray-400 mb-3">
+                  <span>Lesson {lesson.frontmatter.order}</span>
+                  {lesson.frontmatter.duration && (
+                    <>
+                      <span className="text-cyan-500/50">·</span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="w-3.5 h-3.5" />
+                        {lesson.frontmatter.duration}
+                      </span>
+                    </>
+                  )}
+                </div>
+                <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">
+                  {lesson.frontmatter.title}
+                </h1>
+
+                {/* Learning objectives */}
+                {lesson.frontmatter.objectives &&
+                  lesson.frontmatter.objectives.length > 0 && (
+                    <div className="bg-cyan-500/5 border border-cyan-500/20 rounded-lg p-4 mt-4">
+                      <h2 className="text-sm font-semibold text-cyan-400 mb-2 flex items-center gap-2">
+                        <Target className="w-4 h-4" />
+                        What you'll learn
+                      </h2>
+                      <ul className="space-y-1">
+                        {lesson.frontmatter.objectives.map((objective, i) => (
+                          <li
+                            key={i}
+                            className="text-sm text-gray-300 flex items-start gap-2"
+                          >
+                            <span className="text-cyan-400 mt-1">•</span>
+                            {objective}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+              </header>
+
+              {/* Lesson content */}
+              <CourseMarkdownRenderer content={lesson.content} />
+
+              {/* Navigation */}
+              <LessonNavigation
+                courseSlug={params.courseSlug}
+                courseTitle={course.frontmatter.title}
+                prevLesson={
+                  prev
+                    ? { slug: prev.slug, title: prev.frontmatter.title }
+                    : null
+                }
+                nextLesson={
+                  next
+                    ? { slug: next.slug, title: next.frontmatter.title }
+                    : null
+                }
+                currentLesson={progress.current}
+                totalLessons={progress.total}
+              />
+            </article>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/courses/[courseSlug]/page.tsx
+++ b/src/app/courses/[courseSlug]/page.tsx
@@ -1,0 +1,236 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  getAllCourses,
+  getCourse,
+  getCourseLessons,
+  getDifficultyColor,
+} from '@/lib/courses';
+import Header from '@/components/Header';
+import CourseMarkdownRenderer from '@/components/courses/CourseMarkdownRenderer';
+import {
+  ArrowLeft,
+  BookOpen,
+  Clock,
+  BarChart3,
+  PlayCircle,
+  CheckCircle2,
+} from 'lucide-react';
+
+interface CoursePageProps {
+  params: {
+    courseSlug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const courses = await getAllCourses();
+  return courses.map((course) => ({
+    courseSlug: course.slug,
+  }));
+}
+
+export async function generateMetadata({
+  params,
+}: CoursePageProps): Promise<Metadata> {
+  const course = await getCourse(params.courseSlug);
+
+  if (!course) {
+    return {
+      title: 'Course Not Found',
+    };
+  }
+
+  return {
+    title: `${course.frontmatter.title} | Courses`,
+    description: course.frontmatter.description,
+    openGraph: {
+      title: course.frontmatter.title,
+      description: course.frontmatter.description,
+      type: 'website',
+      images: course.frontmatter.featured_image
+        ? [course.frontmatter.featured_image]
+        : [],
+    },
+  };
+}
+
+export default async function CoursePage({ params }: CoursePageProps) {
+  const course = await getCourse(params.courseSlug);
+
+  if (!course) {
+    notFound();
+  }
+
+  const lessons = await getCourseLessons(params.courseSlug);
+  const firstLesson = lessons[0];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 via-black to-gray-900">
+      <Header />
+
+      {/* Back link */}
+      <div className="pt-20">
+        <div className="container mx-auto px-4 py-6 max-w-5xl">
+          <Link
+            href="/courses"
+            className="inline-flex items-center gap-2 text-sm font-medium text-gray-400 hover:text-cyan-400 transition-colors mb-4"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Courses
+          </Link>
+        </div>
+      </div>
+
+      {/* Course content */}
+      <article className="container mx-auto px-4 py-6 max-w-5xl">
+        <div className="grid lg:grid-cols-3 gap-8">
+          {/* Main content */}
+          <div className="lg:col-span-2">
+            {/* Course header */}
+            <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg shadow-sm p-8 md:p-10 mb-8">
+              {/* Badges */}
+              <div className="flex flex-wrap items-center gap-2 mb-4">
+                <span
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${getDifficultyColor(
+                    course.frontmatter.difficulty
+                  )}`}
+                >
+                  <BarChart3 className="w-3.5 h-3.5 mr-1.5" />
+                  {course.frontmatter.difficulty.charAt(0).toUpperCase() +
+                    course.frontmatter.difficulty.slice(1)}
+                </span>
+                {course.frontmatter.duration && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border border-gray-500/30 text-gray-400">
+                    <Clock className="w-3.5 h-3.5 mr-1.5" />
+                    {course.frontmatter.duration}
+                  </span>
+                )}
+              </div>
+
+              {/* Title and description */}
+              <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
+                {course.frontmatter.title}
+              </h1>
+              <p className="text-xl text-gray-400 mb-6">
+                {course.frontmatter.description}
+              </p>
+
+              {/* Tags */}
+              {course.frontmatter.tags && course.frontmatter.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {course.frontmatter.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-3 py-1 bg-cyan-500/10 text-cyan-400 border border-cyan-500/30 rounded-full text-sm"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Course overview content */}
+            {course.content && (
+              <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg shadow-sm p-8 md:p-10">
+                <h2 className="text-2xl font-bold text-white mb-6 flex items-center gap-2">
+                  <BookOpen className="w-6 h-6 text-cyan-400" />
+                  About This Course
+                </h2>
+                <CourseMarkdownRenderer content={course.content} />
+              </div>
+            )}
+          </div>
+
+          {/* Sidebar */}
+          <div className="lg:col-span-1">
+            <div className="sticky top-24 space-y-6">
+              {/* Start button */}
+              {firstLesson && (
+                <Link
+                  href={`/courses/${params.courseSlug}/${firstLesson.slug}`}
+                  className="flex items-center justify-center gap-2 w-full px-6 py-4 bg-gradient-to-r from-cyan-500 to-blue-500 hover:from-cyan-600 hover:to-blue-600 text-white rounded-lg font-semibold transition-all shadow-lg shadow-cyan-500/25 hover:shadow-cyan-500/40"
+                >
+                  <PlayCircle className="w-5 h-5" />
+                  Start Course
+                </Link>
+              )}
+
+              {/* Course stats */}
+              <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg p-6">
+                <h3 className="font-semibold text-lg text-white mb-4">
+                  Course Info
+                </h3>
+                <dl className="space-y-3 text-sm">
+                  <div className="flex justify-between">
+                    <dt className="text-gray-500">Lessons</dt>
+                    <dd className="text-gray-300 font-medium">
+                      {lessons.length}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between">
+                    <dt className="text-gray-500">Difficulty</dt>
+                    <dd className="text-gray-300 font-medium capitalize">
+                      {course.frontmatter.difficulty}
+                    </dd>
+                  </div>
+                  {course.frontmatter.duration && (
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">Duration</dt>
+                      <dd className="text-gray-300 font-medium">
+                        {course.frontmatter.duration}
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+              </div>
+
+              {/* Syllabus */}
+              <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg overflow-hidden">
+                <div className="p-4 border-b border-cyan-500/20">
+                  <h3 className="font-semibold text-lg text-white">Syllabus</h3>
+                </div>
+                <nav className="py-2">
+                  {lessons.map((lesson, index) => (
+                    <Link
+                      key={lesson.slug}
+                      href={`/courses/${params.courseSlug}/${lesson.slug}`}
+                      className="flex items-center gap-3 px-4 py-3 hover:bg-cyan-500/5 transition-colors group"
+                    >
+                      <span className="flex items-center justify-center w-6 h-6 rounded-full bg-cyan-500/10 text-cyan-400 text-xs font-medium group-hover:bg-cyan-500/20">
+                        {lesson.frontmatter.order}
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-gray-300 group-hover:text-white truncate">
+                          {lesson.frontmatter.title}
+                        </p>
+                        {lesson.frontmatter.duration && (
+                          <p className="text-xs text-gray-500">
+                            {lesson.frontmatter.duration}
+                          </p>
+                        )}
+                      </div>
+                    </Link>
+                  ))}
+                </nav>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Back to courses link */}
+        <div className="mt-12">
+          <Link
+            href="/courses"
+            className="inline-flex items-center gap-2 px-4 py-2 border border-cyan-500/30 rounded-md text-sm font-medium text-cyan-400 hover:bg-cyan-400/10 hover:border-cyan-400/50 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to all courses
+          </Link>
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -1,0 +1,120 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { getAllCourses, getDifficultyColor } from '@/lib/courses';
+import Header from '@/components/Header';
+import { BookOpen, Clock, BarChart3, ChevronRight } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Courses | Swarup Donepudi',
+  description: 'Practical courses on Unix, Terraform, and cloud infrastructure',
+};
+
+export default async function CoursesPage() {
+  const courses = await getAllCourses();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 via-black to-gray-900">
+      <Header />
+
+      {/* Header - add padding-top to account for fixed nav */}
+      <div className="pt-20 border-b border-cyan-500/20">
+        <div className="container mx-auto px-4 py-16 max-w-6xl">
+          <h1 className="text-5xl md:text-6xl font-bold text-white mb-4">
+            Courses
+          </h1>
+          <p className="text-xl text-gray-400">
+            Practical, hands-on courses to level up your infrastructure skills
+          </p>
+        </div>
+      </div>
+
+      {/* Courses grid */}
+      <div className="container mx-auto px-4 py-12 max-w-6xl">
+        {courses.length === 0 ? (
+          <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg p-12 text-center">
+            <BookOpen className="w-12 h-12 text-gray-500 mx-auto mb-4" />
+            <p className="text-gray-400 text-lg">
+              No courses available yet. Check back soon!
+            </p>
+          </div>
+        ) : (
+          <div className="grid md:grid-cols-2 gap-6">
+            {courses.map((course) => (
+              <Link
+                key={course.slug}
+                href={`/courses/${course.slug}`}
+                className="block group"
+              >
+                <div className="h-full bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg hover:border-cyan-400/50 transition-all duration-200 overflow-hidden hover:shadow-lg hover:shadow-cyan-500/10">
+                  {/* Course image */}
+                  {course.frontmatter.featured_image && (
+                    <div className="w-full h-48 overflow-hidden">
+                      <img
+                        src={course.frontmatter.featured_image}
+                        alt={course.frontmatter.title}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
+                      />
+                    </div>
+                  )}
+
+                  <div className="p-6">
+                    {/* Badges */}
+                    <div className="flex flex-wrap items-center gap-2 mb-3">
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium border ${getDifficultyColor(
+                          course.frontmatter.difficulty
+                        )}`}
+                      >
+                        <BarChart3 className="w-3 h-3 mr-1" />
+                        {course.frontmatter.difficulty.charAt(0).toUpperCase() +
+                          course.frontmatter.difficulty.slice(1)}
+                      </span>
+                      {course.frontmatter.duration && (
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium border border-gray-500/30 text-gray-400">
+                          <Clock className="w-3 h-3 mr-1" />
+                          {course.frontmatter.duration}
+                        </span>
+                      )}
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium border border-cyan-500/30 text-cyan-400">
+                        <BookOpen className="w-3 h-3 mr-1" />
+                        {course.lessonCount} lessons
+                      </span>
+                    </div>
+
+                    {/* Title and description */}
+                    <h2 className="text-2xl font-bold text-white group-hover:text-cyan-400 transition-colors mb-2">
+                      {course.frontmatter.title}
+                    </h2>
+                    <p className="text-gray-400 text-base mb-4 line-clamp-2">
+                      {course.frontmatter.description}
+                    </p>
+
+                    {/* Tags */}
+                    {course.frontmatter.tags && course.frontmatter.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mb-4">
+                        {course.frontmatter.tags.slice(0, 4).map((tag) => (
+                          <span
+                            key={tag}
+                            className="px-2 py-0.5 bg-cyan-500/10 text-cyan-400 border border-cyan-500/30 rounded text-xs"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* CTA */}
+                    <div className="flex items-center text-cyan-400 text-sm font-medium group-hover:text-cyan-300">
+                      Start Learning
+                      <ChevronRight className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/fastlane/[slug]/page.tsx
+++ b/src/app/fastlane/[slug]/page.tsx
@@ -1,0 +1,93 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { getAllFastlaneEntries, getFastlaneEntry } from '@/lib/fastlane';
+import { formatDate } from '@/lib/content';
+import MarkdownRenderer from '@/components/blog/MarkdownRenderer';
+import Header from '@/components/Header';
+
+interface FastlaneEntryPageProps {
+  params: {
+    slug: string;
+  };
+}
+
+export async function generateStaticParams() {
+  const entries = await getAllFastlaneEntries();
+  return entries.map((entry) => ({
+    slug: entry.slug,
+  }));
+}
+
+export async function generateMetadata({ params }: FastlaneEntryPageProps): Promise<Metadata> {
+  const entry = await getFastlaneEntry(params.slug);
+
+  if (!entry) {
+    return {
+      title: 'Entry Not Found',
+    };
+  }
+
+  return {
+    title: `${entry.frontmatter.title} | Fastlane`,
+    description: entry.excerpt,
+    openGraph: {
+      title: entry.frontmatter.title,
+      description: entry.excerpt,
+      type: 'article',
+      publishedTime: entry.frontmatter.date,
+    },
+  };
+}
+
+export default async function FastlaneEntryPage({ params }: FastlaneEntryPageProps) {
+  const entry = await getFastlaneEntry(params.slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 via-black to-gray-900">
+      <Header />
+
+      {/* Content */}
+      <article className="container mx-auto px-4 pt-28 pb-8 max-w-3xl">
+        <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg shadow-sm p-8 md:p-12">
+          {/* Header */}
+          <header className="mb-8 pb-8 border-b border-cyan-500/20">
+            {/* Date */}
+            <time
+              dateTime={entry.frontmatter.date}
+              className="block text-sm font-medium text-cyan-400 mb-4"
+            >
+              {formatDate(entry.frontmatter.date)}
+            </time>
+
+            {/* Title */}
+            <h1 className="text-3xl md:text-4xl font-bold text-white mb-4">
+              {entry.frontmatter.title}
+            </h1>
+
+            {/* Tags */}
+            {entry.frontmatter.tags && entry.frontmatter.tags.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {entry.frontmatter.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="px-3 py-1 bg-cyan-500/10 text-cyan-400 border border-cyan-500/30 rounded-full text-xs font-medium"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </header>
+
+          {/* Markdown content */}
+          <MarkdownRenderer content={entry.content} />
+        </div>
+
+      </article>
+    </div>
+  );
+}

--- a/src/app/fastlane/page.tsx
+++ b/src/app/fastlane/page.tsx
@@ -1,0 +1,44 @@
+import { Metadata } from 'next';
+import { getAllFastlaneEntries } from '@/lib/fastlane';
+import Header from '@/components/Header';
+import FastlaneTimeline from '@/components/fastlane/FastlaneTimeline';
+
+export const metadata: Metadata = {
+  title: 'Fastlane | Swarup Donepudi',
+  description: "Life's single-threaded stream - thoughts, moments, and observations captured as they happen",
+};
+
+export default async function FastlanePage() {
+  const entries = await getAllFastlaneEntries();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-900 via-black to-gray-900">
+      <Header />
+
+      {/* Header Section */}
+      <div className="pt-20 border-b border-cyan-500/20">
+        <div className="container mx-auto px-4 py-16 max-w-3xl">
+          <h1 className="text-5xl md:text-6xl font-bold text-white mb-4">
+            Fastlane
+          </h1>
+          <p className="text-xl text-gray-400">
+            Life's single-threaded stream
+          </p>
+        </div>
+      </div>
+
+      {/* Timeline Entries */}
+      <div className="container mx-auto px-4 py-12 max-w-3xl">
+        {entries.length === 0 ? (
+          <div className="bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg p-12 text-center">
+            <p className="text-gray-400 text-lg">
+              No entries yet. The journey begins soon.
+            </p>
+          </div>
+        ) : (
+          <FastlaneTimeline entries={entries} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ const navItems = [
   { label: 'Projects', href: '/#projects' },
   { label: 'Blog', href: '/blog' },
   { label: 'Talks', href: '/talks' },
+  { label: 'Courses', href: '/courses' },
 ];
 
 export default function Header({ className = '' }: HeaderProps) {

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -225,7 +225,7 @@ export default function Home() {
             <div className="flex justify-center space-x-8 text-gray-400">
               <a href="/blog" className="hover:text-cyan-400 transition-colors">Blog</a>
               <a href="/talks" className="hover:text-cyan-400 transition-colors">Talks</a>
-              <a href="https://github.com/project-planton" target="_blank" rel="noopener noreferrer" className="hover:text-cyan-400 transition-colors">Open Source</a>
+              <a href="https://github.com/plantonhq" target="_blank" rel="noopener noreferrer" className="hover:text-cyan-400 transition-colors">Open Source</a>
               <a href="https://planton.cloud" target="_blank" rel="noopener noreferrer" className="hover:text-cyan-400 transition-colors">Planton Cloud</a>
             </div>
           </motion.div>

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -35,6 +35,7 @@ const navItems = [
   { label: 'Projects', href: '#projects' },
   { label: 'Blog', href: '/blog' },
   { label: 'Talks', href: '/talks' },
+  { label: 'Courses', href: '/courses' },
 ];
 
 export default function Home() {

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -35,7 +35,6 @@ const navItems = [
   { label: 'Projects', href: '#projects' },
   { label: 'Blog', href: '/blog' },
   { label: 'Talks', href: '/talks' },
-  { label: 'Courses', href: '/courses' },
 ];
 
 export default function Home() {

--- a/src/components/blog/MarkdownRenderer.tsx
+++ b/src/components/blog/MarkdownRenderer.tsx
@@ -97,17 +97,17 @@ export default function MarkdownRenderer({ content, className = '' }: MarkdownRe
           ),
           // Custom lists
           ul: ({ children, ...props }) => (
-            <ul className="list-disc list-inside space-y-2 mb-4 text-gray-300" {...props}>
+            <ul className="list-disc pl-6 space-y-2 mb-4 text-gray-300" {...props}>
               {children}
             </ul>
           ),
           ol: ({ children, ...props }) => (
-            <ol className="list-decimal list-inside space-y-2 mb-4 text-gray-300" {...props}>
+            <ol className="list-decimal pl-6 space-y-2 mb-4 text-gray-300" {...props}>
               {children}
             </ol>
           ),
           li: ({ children, ...props }) => (
-            <li className="text-gray-300" {...props}>
+            <li className="text-gray-300 pl-2" {...props}>
               {children}
             </li>
           ),

--- a/src/components/courses/Callout.tsx
+++ b/src/components/courses/Callout.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import { Info, AlertTriangle, Lightbulb, AlertCircle } from 'lucide-react';
+
+type CalloutVariant = 'info' | 'warning' | 'tip' | 'danger';
+
+interface CalloutProps {
+  variant?: CalloutVariant;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const variantConfig = {
+  info: {
+    icon: Info,
+    bgColor: 'bg-blue-500/10',
+    borderColor: 'border-blue-500/30',
+    iconColor: 'text-blue-400',
+    titleColor: 'text-blue-400',
+  },
+  warning: {
+    icon: AlertTriangle,
+    bgColor: 'bg-yellow-500/10',
+    borderColor: 'border-yellow-500/30',
+    iconColor: 'text-yellow-400',
+    titleColor: 'text-yellow-400',
+  },
+  tip: {
+    icon: Lightbulb,
+    bgColor: 'bg-green-500/10',
+    borderColor: 'border-green-500/30',
+    iconColor: 'text-green-400',
+    titleColor: 'text-green-400',
+  },
+  danger: {
+    icon: AlertCircle,
+    bgColor: 'bg-red-500/10',
+    borderColor: 'border-red-500/30',
+    iconColor: 'text-red-400',
+    titleColor: 'text-red-400',
+  },
+};
+
+const defaultTitles: Record<CalloutVariant, string> = {
+  info: 'Note',
+  warning: 'Warning',
+  tip: 'Tip',
+  danger: 'Danger',
+};
+
+/**
+ * Callout component for highlighting important information
+ * Variants: info, warning, tip, danger
+ */
+export default function Callout({
+  variant = 'info',
+  title,
+  children,
+}: CalloutProps) {
+  const config = variantConfig[variant];
+  const Icon = config.icon;
+  const displayTitle = title || defaultTitles[variant];
+
+  return (
+    <div
+      className={`my-6 rounded-lg border ${config.borderColor} ${config.bgColor} p-4`}
+    >
+      <div className="flex items-start gap-3">
+        <Icon className={`w-5 h-5 mt-0.5 flex-shrink-0 ${config.iconColor}`} />
+        <div className="flex-1 min-w-0">
+          <p className={`font-semibold mb-1 ${config.titleColor}`}>
+            {displayTitle}
+          </p>
+          <div className="text-gray-300 text-sm leading-relaxed">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/CommandExplain.tsx
+++ b/src/components/courses/CommandExplain.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React, { useState } from 'react';
+
+interface CommandPart {
+  text: string;
+  explanation: string;
+  type?: 'command' | 'flag' | 'argument' | 'option' | 'pipe' | 'redirect';
+}
+
+interface CommandExplainProps {
+  parts: CommandPart[];
+  title?: string;
+}
+
+const typeColors: Record<string, string> = {
+  command: 'text-cyan-400 hover:bg-cyan-500/20',
+  flag: 'text-yellow-400 hover:bg-yellow-500/20',
+  argument: 'text-green-400 hover:bg-green-500/20',
+  option: 'text-purple-400 hover:bg-purple-500/20',
+  pipe: 'text-gray-400 hover:bg-gray-500/20',
+  redirect: 'text-orange-400 hover:bg-orange-500/20',
+};
+
+/**
+ * CommandExplain component for breaking down commands with explanations
+ * Each part can be hovered/clicked to show its explanation
+ */
+export default function CommandExplain({ parts, title }: CommandExplainProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  return (
+    <div className="my-6 rounded-lg border border-cyan-500/30 bg-black/60 overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-2 bg-gray-900/80 border-b border-cyan-500/20">
+        <span className="text-sm text-gray-400">
+          {title || 'Command Breakdown'}
+        </span>
+      </div>
+
+      {/* Command display */}
+      <div className="p-4 font-mono text-sm">
+        <div className="flex flex-wrap items-center gap-1">
+          <span className="text-green-400 select-none mr-1">$</span>
+          {parts.map((part, index) => (
+            <button
+              key={index}
+              className={`px-1.5 py-0.5 rounded cursor-pointer transition-colors ${
+                typeColors[part.type || 'command']
+              } ${activeIndex === index ? 'ring-1 ring-current' : ''}`}
+              onMouseEnter={() => setActiveIndex(index)}
+              onMouseLeave={() => setActiveIndex(null)}
+              onClick={() => setActiveIndex(activeIndex === index ? null : index)}
+            >
+              {part.text}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Explanation panel */}
+      <div className="border-t border-cyan-500/20 bg-gray-950/50 p-4 min-h-[60px]">
+        {activeIndex !== null ? (
+          <div className="flex items-start gap-3">
+            <code
+              className={`px-2 py-0.5 rounded text-sm font-mono ${
+                typeColors[parts[activeIndex].type || 'command'].split(' ')[0]
+              } bg-black/40`}
+            >
+              {parts[activeIndex].text}
+            </code>
+            <p className="text-gray-300 text-sm leading-relaxed">
+              {parts[activeIndex].explanation}
+            </p>
+          </div>
+        ) : (
+          <p className="text-gray-500 text-sm italic">
+            Hover or click on any part of the command to see its explanation
+          </p>
+        )}
+      </div>
+
+      {/* Legend */}
+      <div className="border-t border-cyan-500/20 bg-gray-900/40 px-4 py-2">
+        <div className="flex flex-wrap gap-3 text-xs">
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-cyan-400" />
+            <span className="text-gray-400">Command</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-yellow-400" />
+            <span className="text-gray-400">Flag</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-green-400" />
+            <span className="text-gray-400">Argument</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-purple-400" />
+            <span className="text-gray-400">Option</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/CourseMarkdownRenderer.tsx
+++ b/src/components/courses/CourseMarkdownRenderer.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeHighlight from 'rehype-highlight';
+import 'highlight.js/styles/github-dark.css';
+import Terminal from './Terminal';
+import Callout from './Callout';
+
+interface CourseMarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+/**
+ * Extended Markdown renderer for course content
+ * Supports custom components: terminal, callout, tip, warning, info, danger
+ */
+export default function CourseMarkdownRenderer({
+  content,
+  className = '',
+}: CourseMarkdownRendererProps) {
+  return (
+    <div className={`prose prose-lg max-w-none ${className}`}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, rehypeHighlight]}
+        components={{
+          // Custom heading components
+          h1: ({ children, ...props }) => (
+            <h1
+              className="text-4xl font-bold mt-8 mb-4 bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent"
+              {...props}
+            >
+              {children}
+            </h1>
+          ),
+          h2: ({ children, ...props }) => (
+            <h2 className="text-3xl font-semibold mt-8 mb-4 text-gray-100 border-b border-cyan-500/20 pb-2" {...props}>
+              {children}
+            </h2>
+          ),
+          h3: ({ children, ...props }) => (
+            <h3 className="text-2xl font-semibold mt-6 mb-3 text-gray-200" {...props}>
+              {children}
+            </h3>
+          ),
+          h4: ({ children, ...props }) => (
+            <h4 className="text-xl font-semibold mt-4 mb-2 text-gray-300" {...props}>
+              {children}
+            </h4>
+          ),
+          // Custom paragraph
+          p: ({ children, ...props }) => (
+            <p className="text-gray-300 leading-relaxed mb-4" {...props}>
+              {children}
+            </p>
+          ),
+          // Custom links
+          a: ({ children, href, ...props }) => (
+            <a
+              href={href}
+              className="text-cyan-400 hover:text-cyan-300 underline decoration-cyan-500/50"
+              target={href?.startsWith('http') ? '_blank' : undefined}
+              rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+              {...props}
+            >
+              {children}
+            </a>
+          ),
+          // Custom code blocks - enhanced for course content
+          code: ({ className, children, ...props }) => {
+            const inline = !className;
+            return inline ? (
+              <code
+                className="bg-cyan-500/10 text-cyan-300 px-1.5 py-0.5 rounded text-sm font-mono border border-cyan-500/30"
+                {...props}
+              >
+                {children}
+              </code>
+            ) : (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            );
+          },
+          // Custom pre for code blocks
+          pre: ({ children, ...props }) => (
+            <pre
+              className="bg-black/60 text-gray-100 p-4 rounded-lg overflow-x-auto my-4 border border-cyan-500/20"
+              {...props}
+            >
+              {children}
+            </pre>
+          ),
+          // Custom blockquote - styled as callout
+          blockquote: ({ children, ...props }) => (
+            <blockquote
+              className="border-l-4 border-cyan-500 pl-4 italic text-gray-400 my-4 bg-cyan-500/5 py-2 rounded-r"
+              {...props}
+            >
+              {children}
+            </blockquote>
+          ),
+          // Custom lists
+          ul: ({ children, ...props }) => (
+            <ul className="list-disc list-outside ml-6 space-y-2 mb-4 text-gray-300" {...props}>
+              {children}
+            </ul>
+          ),
+          ol: ({ children, ...props }) => (
+            <ol className="list-decimal list-outside ml-6 space-y-2 mb-4 text-gray-300" {...props}>
+              {children}
+            </ol>
+          ),
+          li: ({ children, ...props }) => (
+            <li className="text-gray-300 pl-2" {...props}>
+              {children}
+            </li>
+          ),
+          // Custom strong (bold)
+          strong: ({ children, ...props }) => (
+            <strong className="font-bold text-white" {...props}>
+              {children}
+            </strong>
+          ),
+          // Custom em (italic)
+          em: ({ children, ...props }) => (
+            <em className="italic text-gray-200" {...props}>
+              {children}
+            </em>
+          ),
+          // Custom images
+          img: ({ src, alt, ...props }) => (
+            <img
+              src={src}
+              alt={alt || ''}
+              className="rounded-lg my-4 w-full h-auto border border-cyan-500/20"
+              {...props}
+            />
+          ),
+          // Custom horizontal rule
+          hr: (props) => <hr className="my-8 border-cyan-500/30" {...props} />,
+          // Custom table
+          table: ({ children, ...props }) => (
+            <div className="overflow-x-auto my-4 border border-cyan-500/20 rounded-lg">
+              <table className="min-w-full divide-y divide-cyan-500/20" {...props}>
+                {children}
+              </table>
+            </div>
+          ),
+          th: ({ children, ...props }) => (
+            <th
+              className="px-4 py-2 bg-cyan-500/10 text-left text-sm font-semibold text-gray-200"
+              {...props}
+            >
+              {children}
+            </th>
+          ),
+          td: ({ children, ...props }) => (
+            <td className="px-4 py-2 border-t border-cyan-500/20 text-gray-300" {...props}>
+              {children}
+            </td>
+          ),
+          // Custom components via rehype-raw (HTML in markdown)
+          terminal: ({ node, ...props }: any) => {
+            const command = props.command || '';
+            const output = props.output;
+            const title = props.title;
+            return <Terminal command={command} output={output} title={title} />;
+          },
+          callout: ({ node, ...props }: any) => {
+            const variant = props.variant || 'info';
+            const title = props.title;
+            const children = props.children;
+            return (
+              <Callout variant={variant} title={title}>
+                {children}
+              </Callout>
+            );
+          },
+          tip: ({ node, children, ...props }: any) => (
+            <Callout variant="tip" title={props.title}>
+              {children}
+            </Callout>
+          ),
+          warning: ({ node, children, ...props }: any) => (
+            <Callout variant="warning" title={props.title}>
+              {children}
+            </Callout>
+          ),
+          info: ({ node, children, ...props }: any) => (
+            <Callout variant="info" title={props.title}>
+              {children}
+            </Callout>
+          ),
+          danger: ({ node, children, ...props }: any) => (
+            <Callout variant="danger" title={props.title}>
+              {children}
+            </Callout>
+          ),
+        } as any}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/courses/CourseProgress.tsx
+++ b/src/components/courses/CourseProgress.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+
+interface CourseProgressProps {
+  current: number;
+  total: number;
+  showLabel?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+/**
+ * CourseProgress component for showing visual progress through a course
+ */
+export default function CourseProgress({
+  current,
+  total,
+  showLabel = true,
+  size = 'md',
+}: CourseProgressProps) {
+  const percentage = Math.round((current / total) * 100);
+
+  const sizeClasses = {
+    sm: 'h-1',
+    md: 'h-2',
+    lg: 'h-3',
+  };
+
+  return (
+    <div className="w-full">
+      {showLabel && (
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm text-gray-400">
+            Lesson {current} of {total}
+          </span>
+          <span className="text-sm font-medium text-cyan-400">{percentage}%</span>
+        </div>
+      )}
+      <div
+        className={`w-full bg-gray-800 rounded-full overflow-hidden ${sizeClasses[size]}`}
+      >
+        <div
+          className="h-full bg-gradient-to-r from-cyan-500 to-blue-500 rounded-full transition-all duration-500 ease-out"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/CourseSidebar.tsx
+++ b/src/components/courses/CourseSidebar.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { ChevronDown, ChevronRight, BookOpen, CheckCircle2, Circle } from 'lucide-react';
+import CourseProgress from './CourseProgress';
+
+interface LessonItem {
+  slug: string;
+  title: string;
+  duration?: string;
+  order: number;
+}
+
+interface CourseSidebarProps {
+  courseSlug: string;
+  courseTitle: string;
+  lessons: LessonItem[];
+  currentLessonSlug?: string;
+  className?: string;
+}
+
+/**
+ * CourseSidebar component for showing course outline with current lesson highlighted
+ */
+export default function CourseSidebar({
+  courseSlug,
+  courseTitle,
+  lessons,
+  currentLessonSlug,
+  className = '',
+}: CourseSidebarProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  
+  const currentIndex = currentLessonSlug 
+    ? lessons.findIndex(l => l.slug === currentLessonSlug) + 1
+    : 0;
+
+  return (
+    <div className={`bg-black/40 backdrop-blur-lg border border-cyan-500/20 rounded-lg overflow-hidden ${className}`}>
+      {/* Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between p-4 hover:bg-cyan-500/5 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <BookOpen className="w-5 h-5 text-cyan-400" />
+          <div className="text-left">
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Course</p>
+            <p className="text-sm font-medium text-white">{courseTitle}</p>
+          </div>
+        </div>
+        {isExpanded ? (
+          <ChevronDown className="w-5 h-5 text-gray-400" />
+        ) : (
+          <ChevronRight className="w-5 h-5 text-gray-400" />
+        )}
+      </button>
+
+      {/* Progress bar */}
+      {currentLessonSlug && (
+        <div className="px-4 pb-3">
+          <CourseProgress 
+            current={currentIndex} 
+            total={lessons.length} 
+            size="sm" 
+          />
+        </div>
+      )}
+
+      {/* Lesson list */}
+      {isExpanded && (
+        <div className="border-t border-cyan-500/20">
+          <nav className="py-2">
+            {lessons.map((lesson, index) => {
+              const isActive = lesson.slug === currentLessonSlug;
+              const isPast = currentLessonSlug 
+                ? lessons.findIndex(l => l.slug === currentLessonSlug) > index
+                : false;
+
+              return (
+                <Link
+                  key={lesson.slug}
+                  href={`/courses/${courseSlug}/${lesson.slug}`}
+                  className={`flex items-center gap-3 px-4 py-2.5 transition-colors ${
+                    isActive
+                      ? 'bg-cyan-500/10 border-l-2 border-cyan-400'
+                      : 'hover:bg-cyan-500/5 border-l-2 border-transparent'
+                  }`}
+                >
+                  <span className="flex-shrink-0">
+                    {isPast ? (
+                      <CheckCircle2 className="w-4 h-4 text-green-400" />
+                    ) : isActive ? (
+                      <Circle className="w-4 h-4 text-cyan-400 fill-cyan-400" />
+                    ) : (
+                      <Circle className="w-4 h-4 text-gray-600" />
+                    )}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p
+                      className={`text-sm truncate ${
+                        isActive
+                          ? 'text-cyan-400 font-medium'
+                          : isPast
+                          ? 'text-gray-400'
+                          : 'text-gray-300'
+                      }`}
+                    >
+                      {lesson.order}. {lesson.title}
+                    </p>
+                    {lesson.duration && (
+                      <p className="text-xs text-gray-500">{lesson.duration}</p>
+                    )}
+                  </div>
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/courses/LessonNavigation.tsx
+++ b/src/components/courses/LessonNavigation.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import { ArrowLeft, ArrowRight, Home } from 'lucide-react';
+
+interface LessonInfo {
+  slug: string;
+  title: string;
+}
+
+interface LessonNavigationProps {
+  courseSlug: string;
+  courseTitle: string;
+  prevLesson: LessonInfo | null;
+  nextLesson: LessonInfo | null;
+  currentLesson: number;
+  totalLessons: number;
+}
+
+/**
+ * LessonNavigation component for navigating between lessons
+ * Shows prev/next buttons and progress context
+ */
+export default function LessonNavigation({
+  courseSlug,
+  courseTitle,
+  prevLesson,
+  nextLesson,
+  currentLesson,
+  totalLessons,
+}: LessonNavigationProps) {
+  return (
+    <div className="mt-12 pt-8 border-t border-cyan-500/20">
+      {/* Progress indicator */}
+      <div className="text-center mb-6">
+        <p className="text-sm text-gray-400">
+          Lesson {currentLesson} of {totalLessons}
+        </p>
+      </div>
+
+      {/* Navigation buttons */}
+      <div className="flex items-stretch gap-4">
+        {/* Previous lesson */}
+        <div className="flex-1">
+          {prevLesson ? (
+            <Link
+              href={`/courses/${courseSlug}/${prevLesson.slug}`}
+              className="flex items-center gap-3 p-4 rounded-lg border border-cyan-500/20 bg-black/40 hover:border-cyan-400/50 hover:bg-cyan-500/5 transition-all group h-full"
+            >
+              <ArrowLeft className="w-5 h-5 text-gray-400 group-hover:text-cyan-400 transition-colors flex-shrink-0" />
+              <div className="text-left min-w-0">
+                <p className="text-xs text-gray-500 mb-1">Previous</p>
+                <p className="text-sm text-gray-300 group-hover:text-white transition-colors truncate">
+                  {prevLesson.title}
+                </p>
+              </div>
+            </Link>
+          ) : (
+            <Link
+              href={`/courses/${courseSlug}`}
+              className="flex items-center gap-3 p-4 rounded-lg border border-cyan-500/20 bg-black/40 hover:border-cyan-400/50 hover:bg-cyan-500/5 transition-all group h-full"
+            >
+              <Home className="w-5 h-5 text-gray-400 group-hover:text-cyan-400 transition-colors flex-shrink-0" />
+              <div className="text-left min-w-0">
+                <p className="text-xs text-gray-500 mb-1">Back to</p>
+                <p className="text-sm text-gray-300 group-hover:text-white transition-colors truncate">
+                  {courseTitle}
+                </p>
+              </div>
+            </Link>
+          )}
+        </div>
+
+        {/* Next lesson */}
+        <div className="flex-1">
+          {nextLesson ? (
+            <Link
+              href={`/courses/${courseSlug}/${nextLesson.slug}`}
+              className="flex items-center justify-end gap-3 p-4 rounded-lg border border-cyan-500/20 bg-black/40 hover:border-cyan-400/50 hover:bg-cyan-500/5 transition-all group h-full"
+            >
+              <div className="text-right min-w-0">
+                <p className="text-xs text-gray-500 mb-1">Next</p>
+                <p className="text-sm text-gray-300 group-hover:text-white transition-colors truncate">
+                  {nextLesson.title}
+                </p>
+              </div>
+              <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-cyan-400 transition-colors flex-shrink-0" />
+            </Link>
+          ) : (
+            <Link
+              href={`/courses/${courseSlug}`}
+              className="flex items-center justify-end gap-3 p-4 rounded-lg border border-green-500/30 bg-green-500/10 hover:border-green-400/50 hover:bg-green-500/20 transition-all group h-full"
+            >
+              <div className="text-right min-w-0">
+                <p className="text-xs text-green-400 mb-1">Completed!</p>
+                <p className="text-sm text-gray-300 group-hover:text-white transition-colors truncate">
+                  Back to Course
+                </p>
+              </div>
+              <Home className="w-5 h-5 text-green-400 flex-shrink-0" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/courses/Terminal.tsx
+++ b/src/components/courses/Terminal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, Terminal as TerminalIcon } from 'lucide-react';
+
+interface TerminalProps {
+  command: string;
+  output?: string;
+  title?: string;
+  showPrompt?: boolean;
+  copyable?: boolean;
+}
+
+/**
+ * Terminal component for displaying commands with optional output
+ * Features: copy button, syntax highlighting, optional output section
+ */
+export default function Terminal({
+  command,
+  output,
+  title,
+  showPrompt = true,
+  copyable = true,
+}: TerminalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  return (
+    <div className="my-6 rounded-lg overflow-hidden border border-cyan-500/30 bg-black/60">
+      {/* Terminal header */}
+      <div className="flex items-center justify-between px-4 py-2 bg-gray-900/80 border-b border-cyan-500/20">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1.5">
+            <div className="w-3 h-3 rounded-full bg-red-500/80" />
+            <div className="w-3 h-3 rounded-full bg-yellow-500/80" />
+            <div className="w-3 h-3 rounded-full bg-green-500/80" />
+          </div>
+          {title && (
+            <span className="ml-2 text-sm text-gray-400 flex items-center gap-1.5">
+              <TerminalIcon className="w-3.5 h-3.5" />
+              {title}
+            </span>
+          )}
+        </div>
+        {copyable && (
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs text-gray-400 hover:text-cyan-400 transition-colors rounded hover:bg-cyan-500/10"
+            title="Copy command"
+          >
+            {copied ? (
+              <>
+                <Check className="w-3.5 h-3.5 text-green-400" />
+                <span className="text-green-400">Copied!</span>
+              </>
+            ) : (
+              <>
+                <Copy className="w-3.5 h-3.5" />
+                <span>Copy</span>
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Command section */}
+      <div className="p-4 font-mono text-sm">
+        <div className="flex items-start gap-2">
+          {showPrompt && (
+            <span className="text-green-400 select-none">$</span>
+          )}
+          <code className="text-gray-100 break-all">{command}</code>
+        </div>
+      </div>
+
+      {/* Output section */}
+      {output && (
+        <div className="border-t border-cyan-500/20 bg-gray-950/50 p-4 font-mono text-sm">
+          <pre className="text-gray-400 whitespace-pre-wrap overflow-x-auto">
+            {output}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/fastlane/FastlaneTimeline.tsx
+++ b/src/components/fastlane/FastlaneTimeline.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ChevronDown, ExternalLink, Link as LinkIcon, Check } from 'lucide-react';
+import MarkdownRenderer from '@/components/blog/MarkdownRenderer';
+
+/**
+ * Client-safe date formatter
+ */
+function formatDate(dateString: string): string {
+  try {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  } catch {
+    return dateString;
+  }
+}
+
+interface FastlaneEntry {
+  slug: string;
+  content: string;
+  excerpt: string;
+  frontmatter: {
+    title: string;
+    date: string;
+    tags?: string[];
+  };
+}
+
+interface FastlaneTimelineProps {
+  entries: FastlaneEntry[];
+}
+
+export default function FastlaneTimeline({ entries }: FastlaneTimelineProps) {
+  const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
+  const [copiedSlug, setCopiedSlug] = useState<string | null>(null);
+
+  const toggleEntry = (slug: string) => {
+    setExpandedSlug(expandedSlug === slug ? null : slug);
+  };
+
+  const copyLink = async (slug: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const url = `${window.location.origin}/fastlane/${slug}`;
+    await navigator.clipboard.writeText(url);
+    setCopiedSlug(slug);
+    setTimeout(() => setCopiedSlug(null), 2000);
+  };
+
+  const openInNewPage = (slug: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    window.open(`/fastlane/${slug}`, '_blank');
+  };
+
+  return (
+    <div className="space-y-1">
+      {entries.map((entry) => {
+        const isExpanded = expandedSlug === entry.slug;
+        const isCopied = copiedSlug === entry.slug;
+
+        return (
+          <article
+            key={entry.slug}
+            className="relative"
+          >
+            {/* Clickable header */}
+            <div
+              onClick={() => toggleEntry(entry.slug)}
+              className="relative py-8 px-6 -mx-6 rounded-lg hover:bg-white/[0.02] transition-all duration-200 cursor-pointer group"
+            >
+              {/* Date and action icons row */}
+              <div className="flex items-center justify-between mb-3">
+                <time
+                  dateTime={entry.frontmatter.date}
+                  className="text-sm font-medium text-cyan-400"
+                >
+                  {formatDate(entry.frontmatter.date)}
+                </time>
+
+                {/* Action icons */}
+                <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {/* Copy link */}
+                  <button
+                    onClick={(e) => copyLink(entry.slug, e)}
+                    className="p-1.5 rounded-md hover:bg-cyan-500/10 text-gray-400 hover:text-cyan-400 transition-colors"
+                    title="Copy link"
+                  >
+                    {isCopied ? (
+                      <Check className="w-4 h-4 text-green-400" />
+                    ) : (
+                      <LinkIcon className="w-4 h-4" />
+                    )}
+                  </button>
+
+                  {/* Open in new page */}
+                  <button
+                    onClick={(e) => openInNewPage(entry.slug, e)}
+                    className="p-1.5 rounded-md hover:bg-cyan-500/10 text-gray-400 hover:text-cyan-400 transition-colors"
+                    title="Open in new page"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </button>
+
+                  {/* Expand/collapse indicator */}
+                  <div className={`p-1.5 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                    <ChevronDown className="w-4 h-4" />
+                  </div>
+                </div>
+              </div>
+
+              {/* Title */}
+              <h2 className="text-xl font-semibold text-white group-hover:text-cyan-400 transition-colors mb-3">
+                {entry.frontmatter.title}
+              </h2>
+
+              {/* Excerpt (only when collapsed) */}
+              {!isExpanded && (
+                <p className="text-gray-400 text-base leading-relaxed mb-4">
+                  {entry.excerpt}
+                </p>
+              )}
+
+              {/* Tags */}
+              {entry.frontmatter.tags && entry.frontmatter.tags.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {entry.frontmatter.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2 py-0.5 bg-cyan-500/10 text-cyan-400/70 border border-cyan-500/20 rounded text-xs"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Expanded content */}
+            {isExpanded && (
+              <div className="px-6 -mx-6 pb-8 pt-2">
+                <MarkdownRenderer content={entry.content} />
+              </div>
+            )}
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/portfolio/Empire.jsx
+++ b/src/components/portfolio/Empire.jsx
@@ -28,7 +28,7 @@ const projects = [
     color: 'from-green-500 to-emerald-500',
     icon: Code,
     links: {
-      github: 'https://github.com/plantoncloud/gitr',
+      github: 'https://github.com/swarupdonepudi/gitr',
       website: 'https://gitr.dev/'
     }
   },
@@ -56,7 +56,7 @@ const projects = [
     color: 'from-orange-500 to-red-500',
     icon: Globe,
     links: {
-      github: 'https://github.com/plantoncloud/mactl'
+      github: 'https://github.com/plantonhq/mactl'
     }
   }
 ];

--- a/src/components/talks/2025-11-29-hyderabad-cncf-meetup/TalkPresentation.tsx
+++ b/src/components/talks/2025-11-29-hyderabad-cncf-meetup/TalkPresentation.tsx
@@ -211,7 +211,7 @@ function Slide05ProjectPlanton() {
         </div>
 
         <p className="text-lg text-gray-400 pt-6 text-center">
-          🌐 project-planton.org • github.com/project-planton/project-planton
+          🌐 project-planton.org • github.com/plantonhq/project-planton
         </p>
       </motion.div>
     </div>
@@ -909,7 +909,7 @@ function Slide22GetInvolved() {
         <p className="text-2xl text-cyan-400 mb-8">Project Planton is open source</p>
         <div className="space-y-6 text-gray-200 text-xl">
           <p>
-            ⭐ <strong className="text-white">Star the repo:</strong> github.com/project-planton/project-planton
+            ⭐ <strong className="text-white">Star the repo:</strong> github.com/plantonhq/project-planton
           </p>
           <p>
             🔨 <strong className="text-white">Add deployment components</strong> for your favorite cloud services
@@ -997,7 +997,7 @@ function Slide24ThankYou() {
             <div className="bg-white/5 rounded-lg p-6">
               <p className="text-white font-semibold mb-2">Project Planton (OSS)</p>
               <p>project-planton.org</p>
-              <p>github.com/project-planton/project-planton</p>
+              <p>github.com/plantonhq/project-planton</p>
             </div>
             <div className="bg-white/5 rounded-lg p-6">
               <p className="text-white font-semibold mb-2">Connect</p>

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -52,8 +52,8 @@ export function generateSlugFromPath(filePath: string): string {
   // Extract filename without extension
   const basename = path.basename(filePath, path.extname(filePath));
   
-  // Only strip date prefix for blog content, keep it for talks
-  const shouldStripDate = filePath.includes('/blog/');
+  // Strip date prefix for blog and fastlane content, keep it for talks
+  const shouldStripDate = filePath.includes('/blog/') || filePath.includes('/fastlane/');
   
   // If it's index.md, use the parent directory name
   if (basename === 'index' || basename === 'README') {

--- a/src/lib/courses.ts
+++ b/src/lib/courses.ts
@@ -1,0 +1,221 @@
+import {
+  getMarkdownContent,
+  generateExcerpt,
+  sortByDate,
+  MarkdownContent,
+  FrontmatterData,
+} from './content';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Course-specific utilities for managing courses and lessons
+ */
+
+export interface CourseFrontmatter extends FrontmatterData {
+  title: string;
+  description: string;
+  difficulty: 'beginner' | 'intermediate' | 'advanced';
+  duration: string;
+  tags: string[];
+  featured_image?: string;
+  status?: 'draft' | 'published';
+}
+
+export interface LessonFrontmatter extends FrontmatterData {
+  title: string;
+  order: number;
+  duration?: string;
+  objectives?: string[];
+}
+
+export interface Course extends MarkdownContent {
+  frontmatter: CourseFrontmatter;
+  lessonCount: number;
+}
+
+export interface Lesson extends MarkdownContent {
+  frontmatter: LessonFrontmatter;
+  courseSlug: string;
+}
+
+const COURSES_DIR = 'public/courses';
+
+/**
+ * Get all courses
+ */
+export async function getAllCourses(): Promise<Course[]> {
+  try {
+    const coursesPath = path.join(process.cwd(), COURSES_DIR);
+    
+    if (!fs.existsSync(coursesPath)) {
+      return [];
+    }
+
+    const entries = fs.readdirSync(coursesPath, { withFileTypes: true });
+    const courses: Course[] = [];
+
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const course = await getCourse(entry.name);
+        if (course && course.frontmatter.status !== 'draft') {
+          courses.push(course);
+        }
+      }
+    }
+
+    // Sort by title alphabetically
+    return courses.sort((a, b) => 
+      a.frontmatter.title.localeCompare(b.frontmatter.title)
+    );
+  } catch (error) {
+    console.error('Error getting all courses:', error);
+    return [];
+  }
+}
+
+/**
+ * Get a single course by slug
+ */
+export async function getCourse(slug: string): Promise<Course | null> {
+  const filePath = `${COURSES_DIR}/${slug}/index.md`;
+  const content = await getMarkdownContent(filePath);
+
+  if (!content) {
+    return null;
+  }
+
+  // Ensure required fields exist
+  if (!content.frontmatter.title) {
+    console.warn(`Course ${filePath} is missing required 'title' field`);
+    return null;
+  }
+
+  if (!content.frontmatter.description) {
+    console.warn(`Course ${filePath} is missing required 'description' field`);
+    return null;
+  }
+
+  // Count lessons
+  const lessons = await getCourseLessons(slug);
+
+  return {
+    ...content,
+    slug,
+    frontmatter: content.frontmatter as CourseFrontmatter,
+    lessonCount: lessons.length,
+  };
+}
+
+/**
+ * Get all lessons for a course
+ */
+export async function getCourseLessons(courseSlug: string): Promise<Lesson[]> {
+  try {
+    const lessonsPath = path.join(process.cwd(), COURSES_DIR, courseSlug, 'lessons');
+    
+    if (!fs.existsSync(lessonsPath)) {
+      return [];
+    }
+
+    const files = fs.readdirSync(lessonsPath);
+    const lessons: Lesson[] = [];
+
+    for (const file of files) {
+      if (file.endsWith('.md')) {
+        const lessonSlug = file.replace('.md', '');
+        const lesson = await getLesson(courseSlug, lessonSlug);
+        if (lesson) {
+          lessons.push(lesson);
+        }
+      }
+    }
+
+    // Sort by order
+    return lessons.sort((a, b) => a.frontmatter.order - b.frontmatter.order);
+  } catch (error) {
+    console.error(`Error getting lessons for course ${courseSlug}:`, error);
+    return [];
+  }
+}
+
+/**
+ * Get a single lesson by course and lesson slug
+ */
+export async function getLesson(courseSlug: string, lessonSlug: string): Promise<Lesson | null> {
+  const filePath = `${COURSES_DIR}/${courseSlug}/lessons/${lessonSlug}.md`;
+  const content = await getMarkdownContent(filePath);
+
+  if (!content) {
+    return null;
+  }
+
+  // Ensure required fields exist
+  if (!content.frontmatter.title) {
+    console.warn(`Lesson ${filePath} is missing required 'title' field`);
+    return null;
+  }
+
+  if (content.frontmatter.order === undefined) {
+    console.warn(`Lesson ${filePath} is missing required 'order' field`);
+    return null;
+  }
+
+  return {
+    ...content,
+    slug: lessonSlug,
+    courseSlug,
+    frontmatter: content.frontmatter as LessonFrontmatter,
+  };
+}
+
+/**
+ * Get adjacent lessons (prev/next) for navigation
+ */
+export async function getAdjacentLessons(
+  courseSlug: string,
+  currentLessonSlug: string
+): Promise<{ prev: Lesson | null; next: Lesson | null }> {
+  const lessons = await getCourseLessons(courseSlug);
+  const currentIndex = lessons.findIndex(l => l.slug === currentLessonSlug);
+
+  if (currentIndex === -1) {
+    return { prev: null, next: null };
+  }
+
+  return {
+    prev: currentIndex > 0 ? lessons[currentIndex - 1] : null,
+    next: currentIndex < lessons.length - 1 ? lessons[currentIndex + 1] : null,
+  };
+}
+
+/**
+ * Get lesson progress info
+ */
+export function getLessonProgress(
+  lessons: Lesson[],
+  currentLessonSlug: string
+): { current: number; total: number; percentage: number } {
+  const currentIndex = lessons.findIndex(l => l.slug === currentLessonSlug);
+  const current = currentIndex + 1;
+  const total = lessons.length;
+  const percentage = Math.round((current / total) * 100);
+
+  return { current, total, percentage };
+}
+
+/**
+ * Get difficulty color class
+ */
+export function getDifficultyColor(difficulty: string): string {
+  switch (difficulty) {
+    case 'beginner':
+      return 'bg-green-500/20 text-green-400 border-green-500/30';
+    case 'intermediate':
+      return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
+    case 'advanced':
+      return 'bg-red-500/20 text-red-400 border-red-500/30';
+    default:
+      return 'bg-gray-500/20 text-gray-400 border-gray-500/30';
+  }
+}

--- a/src/lib/fastlane.ts
+++ b/src/lib/fastlane.ts
@@ -1,0 +1,134 @@
+import {
+  getMarkdownContent,
+  scanMarkdownFiles,
+  generateExcerpt,
+  sortByDate,
+  MarkdownContent,
+  FrontmatterData,
+} from './content';
+
+/**
+ * Fastlane-specific utilities
+ * 
+ * Fastlane is a personal timeline - quick captures of thoughts and moments.
+ * Unlike blog posts, entries are minimal: just title, date, and optional tags.
+ */
+
+export interface FastlaneEntryFrontmatter extends FrontmatterData {
+  title: string;
+  date: string;
+  tags?: string[];
+}
+
+export interface FastlaneEntry extends MarkdownContent {
+  frontmatter: FastlaneEntryFrontmatter;
+  excerpt: string;
+}
+
+const FASTLANE_DIR = 'public/fastlane';
+
+/**
+ * Get all fastlane entries sorted by date (newest first)
+ */
+export async function getAllFastlaneEntries(): Promise<FastlaneEntry[]> {
+  const markdownFiles = scanMarkdownFiles(FASTLANE_DIR);
+  const entries: FastlaneEntry[] = [];
+
+  for (const file of markdownFiles) {
+    const entry = await getFastlaneEntry(file);
+    if (entry) {
+      entries.push(entry);
+    }
+  }
+
+  return sortByDate(entries);
+}
+
+/**
+ * Get a single fastlane entry by slug or file path
+ */
+export async function getFastlaneEntry(slugOrPath: string): Promise<FastlaneEntry | null> {
+  let filePath: string;
+
+  if (slugOrPath.includes('/')) {
+    // Already a path
+    filePath = slugOrPath;
+  } else {
+    // Find file by slug, accounting for date prefixes (YYYY-MM-DD-)
+    const fs = await import('fs');
+    const path = await import('path');
+    const fastlanePath = path.join(process.cwd(), FASTLANE_DIR);
+
+    // First try exact match (backward compatibility)
+    const exactMatch = `${FASTLANE_DIR}/${slugOrPath}.md`;
+    if (fs.existsSync(path.join(process.cwd(), exactMatch))) {
+      filePath = exactMatch;
+    } else {
+      // Search for files with date prefix (YYYY-MM-DD-slug.md)
+      const files = fs.readdirSync(fastlanePath);
+      const matchingFile = files.find(file => {
+        const datePrefix = /^\d{4}-\d{2}-\d{2}-/;
+        if (datePrefix.test(file) && file.endsWith('.md')) {
+          const fileWithoutDate = file.replace(datePrefix, '');
+          return fileWithoutDate === `${slugOrPath}.md`;
+        }
+        return false;
+      });
+
+      if (matchingFile) {
+        filePath = `${FASTLANE_DIR}/${matchingFile}`;
+      } else {
+        // File not found
+        filePath = `${FASTLANE_DIR}/${slugOrPath}.md`;
+      }
+    }
+  }
+
+  const content = await getMarkdownContent(filePath);
+
+  if (!content) {
+    return null;
+  }
+
+  // Validate required fields
+  if (!content.frontmatter.title) {
+    console.warn(`Fastlane entry ${filePath} is missing required 'title' field`);
+    return null;
+  }
+
+  if (!content.frontmatter.date) {
+    console.warn(`Fastlane entry ${filePath} is missing required 'date' field`);
+    return null;
+  }
+
+  // Generate excerpt from content
+  const excerpt = generateExcerpt(content.content, 150);
+
+  return {
+    ...content,
+    frontmatter: content.frontmatter as FastlaneEntryFrontmatter,
+    excerpt,
+  };
+}
+
+/**
+ * Get recent fastlane entries (for potential homepage widget or other uses)
+ */
+export async function getRecentFastlaneEntries(limit: number = 5): Promise<FastlaneEntry[]> {
+  const allEntries = await getAllFastlaneEntries();
+  return allEntries.slice(0, limit);
+}
+
+/**
+ * Get all unique tags from fastlane entries
+ */
+export async function getAllFastlaneTags(): Promise<string[]> {
+  const allEntries = await getAllFastlaneEntries();
+  const tagsSet = new Set<string>();
+
+  allEntries.forEach(entry => {
+    entry.frontmatter.tags?.forEach(tag => tagsSet.add(tag));
+  });
+
+  return Array.from(tagsSet).sort();
+}


### PR DESCRIPTION
## Summary

Adds a new "Fastlane" feature - a personal timeline accessible at `/fastlane` for capturing day-to-day thoughts and moments without the overhead of polished blog posts. Inspired by "The Millionaire Fastlane" book philosophy of choosing the fast lane in life.

## Context

There's content that happens on a day-to-day basis that deserves a place to be captured quickly - not as polished blog posts, but as authentic moments. Fastlane provides this space with a streamlined UX: expand entries in-place, copy shareable links, or escape to dedicated pages when needed.

## Changes

- Add `public/fastlane/` content directory with README and example entries
- Create `src/lib/fastlane.ts` with TypeScript utilities for reading/parsing entries
- Add timeline listing page at `/fastlane` with accordion-style expand/collapse
- Add individual entry pages at `/fastlane/[slug]` for sharing
- Create `FastlaneTimeline` client component with:
  - Click to expand/collapse entries in-place (only one at a time)
  - Copy link icon (copies shareable URL to clipboard)
  - External link icon (opens entry in new page)
- Update `src/lib/content.ts` to strip date prefixes for fastlane URLs
- Fix ordered list rendering in `MarkdownRenderer` (numbers staying on same line as content)
- Add `.cursor/rules/add-donepudi-me-fastlane-entry.mdc` for quick entry creation

## Implementation notes

- Fastlane is intentionally NOT linked in navigation - discovered only by typing `/fastlane`
- Reuses existing `MarkdownRenderer` component (no duplication)
- Minimal frontmatter required: just `title` and `date` (tags optional, excerpt auto-generated)
- Architecture mirrors blog for consistency but optimized for quick captures

## Visual changes

- Timeline page shows entries with date, title, excerpt, and optional tags
- Expanded entries display full markdown content inline (no black box background)
- Action icons appear on hover (link copy, external link, chevron indicator)
- Individual entry pages have clean layout without back navigation breadcrumbs

## Breaking changes

None

## Test plan

- [x] Build passes (`make build`)
- [x] Timeline page renders at `/fastlane`
- [x] Individual entry pages render at `/fastlane/[slug]`
- [x] Expand/collapse works correctly
- [x] Copy link copies correct URL to clipboard
- [x] External link opens entry in new tab

## Performance impact

No significant impact - static generation for all pages

## Checklist

- [x] Responsive design tested on mobile/desktop
- [x] No console errors or warnings
- [x] Content renders correctly
- [x] Markdown lists display properly (numbers inline with content)